### PR TITLE
v0.11.0 Updated node-ios-device to 0.9.1.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ioslib",
-  "version": "0.10.5",
+  "version": "0.11.0",
   "description": "iOS Utility Library",
   "keywords": [
     "appcelerator",
@@ -42,7 +42,7 @@
     "bplist-parser": "0.1.1",
     "mkdirp": "0.5.1",
     "node-appc": "0.2.35",
-    "node-ios-device": "0.8.3"
+    "node-ios-device": "0.9.1"
   },
   "devDependencies": {
     "mocha": "^2.4.5",


### PR DESCRIPTION
Same as https://github.com/appcelerator/ioslib/pull/34, testing to see if the travis CI test is going to fail for this one.