### PR TITLE
Support Xcode 8.3.3 and iOS 10.3.1

### DIFF
--- a/lib/xcode.js
+++ b/lib/xcode.js
@@ -175,6 +175,41 @@ exports.detect = function detect(options, callback) {
 			var vers = findSDKs(dir, sdkRegExp),
 				simRuntimesDir = '/Library/Developer/CoreSimulator/Profiles/Runtimes';
 
+			if (appc.version.gte(xcodeVer, '7.0')) {
+				var simulatorRuntimeRegex = /\.simruntime$/;
+				var simulatorRuntimesPath;
+				if (appc.version.gte(xcodeVer, '9.0')) {
+					// Simulator runtimes moved to the OS platform path of the respective simulator in Xcode 9
+					var realSdkPath = dir.replace('Simulator.platform', 'OS.platform');
+					simulatorRuntimesPath = path.resolve(realSdkPath, '../Library/CoreSimulator/Profiles/Runtimes');
+				} else {
+					simulatorRuntimesPath = path.resolve(dir, '../Library/CoreSimulator/Profiles/Runtimes');
+				}
+				if (fs.existsSync(simulatorRuntimesPath)) {
+					fs.readdirSync(simulatorRuntimesPath).forEach(function (name) {
+						var runtimePackagePath = path.join(simulatorRuntimesPath, name);
+						if (!fs.existsSync(runtimePackagePath) || !fs.statSync(runtimePackagePath).isDirectory()) {
+							return;
+						}
+
+						if (!simulatorRuntimeRegex.test(name)) {
+							return;
+						}
+
+						var profilePlistPathAndFilename = path.join(runtimePackagePath, 'Contents', 'Resources', 'profile.plist');
+						if (fs.existsSync(profilePlistPathAndFilename)) {
+							var runtimeProfile = new appc.plist(profilePlistPathAndFilename);
+							if (runtimeProfile && runtimeProfile.defaultVersionString) {
+								var runtimeVersion = runtimeProfile.defaultVersionString;
+								if (vers.indexOf(runtimeVersion) === -1) {
+									vers.push(runtimeVersion);
+								}
+							}
+						}
+					});
+				}
+			}
+
 			// for Xcode >=6.2 <7.0, the simulators are in a global directory
 			if (fs.existsSync(simRuntimesDir) && (!xcodeVer || appc.version.gte(xcodeVer, '6.2'))) {
 				fs.readdirSync(simRuntimesDir).forEach(function (name) {


### PR DESCRIPTION
Since the plain SDK version detection is not enough with 10.3.1, i read the runtime's profile.plist and extract the defaultVersion. I also changed the detection this way because with Xcode 9 the filename of the runtime package doesn't contain the version number anymore.