### PR TITLE
[DAEMON-209] Fixed bug where extract teams from provisioning profiles…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# v2.0.6 (Dec 14, 2017)
+
+ - Fixed bug where extract teams from provisioning profiles would fail if any provisioning profiles
+   didn't have any associated teams [DAEMON-209].
+
 # v2.0.5 (Dec 12, 2017)
 
  - Updated to node-ios-device@1.5.0 which added support for Node.js 9.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ioslib",
-  "version": "2.0.5",
+  "version": "2.0.6",
   "publishConfig": {
     "tag": "next"
   },

--- a/src/teams.js
+++ b/src/teams.js
@@ -31,9 +31,11 @@ export function buildTeamsFromProvisioningProfiles(profiles) {
 	for (const type of Object.keys(profiles)) {
 		if (Array.isArray(profiles[type])) {
 			for (const profile of profiles[type]) {
-				for (const id of profile.teamIds) {
-					if (id) {
-						teams[id] = id;
+				if (Array.isArray(profile.teamIds)) {
+					for (const id of profile.teamIds) {
+						if (id) {
+							teams[id] = id;
+						}
 					}
 				}
 				if (profile.teamId) {


### PR DESCRIPTION
[DAEMON-209] Fixed bug where extract teams from provisioning profiles would fail if any provisioning profiles didn't have any associated teams.