### PR TITLE
[TIMOB-26426] Remove hardcoded support for xcode >=6

### DIFF
--- a/lib/xcode.js
+++ b/lib/xcode.js
@@ -243,9 +243,6 @@ exports.detect = function detect(options, callback) {
 			globalSimRuntimes = findSimRuntimes('/Library/Developer/CoreSimulator/Profiles/Runtimes'),
 			xcodes = [];
 
-		// since we do not support Xcode 5 and below, weed them out
-		options.supportedVersions = (options.supportedVersions ? options.supportedVersions + '||' : '') + '>=6.0.0';
-
 		async.series([
 			// build the list of searchPaths
 			function detectOSXenv(next) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "ioslib",
-  "version": "1.7.5",
+  "version": "1.7.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ioslib",
-  "version": "1.7.5",
+  "version": "1.7.6",
   "description": "iOS Utility Library",
   "keywords": [
     "appcelerator",


### PR DESCRIPTION
https://jira.appcelerator.org/browse/TIMOB-26426

Having this here causes ioslib to state that every xcode >=6.0.0 is supported, which I'm fairly sure we don't want.