### PR TITLE
fix: properly detect Xcode 11 CoreSimulator directory

### DIFF
--- a/lib/xcode.js
+++ b/lib/xcode.js
@@ -390,7 +390,11 @@ exports.detect = function detect(options, callback) {
 
 						// Xcode 9 moved CoreSimulator into the "OS" directory instead of the "Simulator" directory
 						path.join(xc.path, 'Platforms', 'iPhoneOS.platform', 'Developer', 'Library', 'CoreSimulator', 'Profiles'),
-						path.join(xc.path, 'Platforms', 'WatchOS.platform', 'Developer', 'Library', 'CoreSimulator', 'Profiles')
+						path.join(xc.path, 'Platforms', 'WatchOS.platform', 'Developer', 'Library', 'CoreSimulator', 'Profiles'),
+
+						// Xcode 11 moved CoreSimulator into the "Library/Developer" directory instead of the "Developer/Library" directory
+						path.join(xc.path, 'Platforms', 'iPhoneOS.platform', 'Library', 'Developer', 'CoreSimulator', 'Profiles'),
+						path.join(xc.path, 'Platforms', 'WatchOS.platform', 'Library', 'Developer', 'CoreSimulator', 'Profiles')
 					];
 
 					deviceTypesPaths.forEach(function (deviceTypePath) {


### PR DESCRIPTION
Xcode 11 Beta 3 seems to have changed the `CoreSimulator` path for iOS and WatchOS.