### PR TITLE
v1.7.14

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright 2014-2018 by Appcelerator, Inc.
+Copyright 2014-2019 by Appcelerator, Inc.
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/lib/simctl.js
+++ b/lib/simctl.js
@@ -16,8 +16,6 @@
 const appc = require('node-appc');
 const async = require('async');
 const debug = require('debug');
-const path = require('path');
-const fs = require('fs');
 const __ = appc.i18n(__dirname).__;
 
 exports.activatePair = activatePair;

--- a/lib/simulator.js
+++ b/lib/simulator.js
@@ -1806,7 +1806,8 @@ function list(options, callback) {
 			devicetypes: [],
 			runtimes: [],
 			devices: {},
-			pairs: {}
+			pairs: {},
+			iosSimToWatchSimToPair: {}
 		};
 
 		const xcodes = Object.keys(xcodeInfo.xcode).filter(function (ver) { return xcodeInfo.xcode[ver].supported; });
@@ -1842,8 +1843,12 @@ function list(options, callback) {
 				});
 
 				Object.keys(info.pairs).forEach(function (udid) {
-					if (!results.pairs[udid]) {
-						results.pairs[udid] = info.pairs[udid];
+					var pair = info.pairs[udid];
+					results.pairs[udid] || (results.pairs[udid] = pair);
+					var m = pair.state.match(/^\(((?:in)?active),/);
+					if (m) {
+						results.iosSimToWatchSimToPair[pair.phone.udid] || (results.iosSimToWatchSimToPair[pair.phone.udid] = {});
+						results.iosSimToWatchSimToPair[pair.phone.udid][pair.watch.udid] = { udid: udid, active: m[1] === 'active' };
 					}
 				});
 

--- a/lib/simulator.js
+++ b/lib/simulator.js
@@ -111,6 +111,9 @@ function detect(options, callback) {
 				version:        '1.0',
 				type:           'watchos',
 
+				simctl:         null,
+				simulator:      null,
+
 				deviceType:     null,
 				deviceName:     name,
 				deviceDir:      null,
@@ -175,18 +178,62 @@ function detect(options, callback) {
 				return callback(null, results);
 			}
 
+			const deviceTypeLookup = {};
+			const runtimeLookup = {};
+			xcodeIds.forEach(function (xcodeId) {
+				var xc = xcodeInfo.xcode[xcodeId];
+
+				Object.keys(xc.simDeviceTypes).forEach(function (id) {
+					deviceTypeLookup[id] = {
+						name:          xc.simDeviceTypes[id].name,
+						model:         xc.simDeviceTypes[id].model,
+						supportsWatch: xc.simDeviceTypes[id].supportsWatch,
+						xcodeId:       xcodeId
+					};
+				});
+
+				Object.keys(xc.simRuntimes).forEach(function (id) {
+					runtimeLookup[id] = {
+						name:      xc.simRuntimes[id].name,
+						version:   xc.simRuntimes[id].version,
+						simctl:    xc.executables.simctl,
+						simulator: xc.executables[/watch/i.test(xc.simRuntimes[id].name) ? 'watchsimulator' : 'simulator'],
+						xcodeId:   xcodeId
+					};
+				});
+			});
+
 			simctl.list({ simctl: xcodeInfo.selectedXcode.executables.simctl }, function (err, info) {
 				if (err) {
 					return callback(err);
 				}
 
-				// create a lookup of runtimes from simctl
-				var simctlRuntimes = {};
+				// find the missing global devicetypes and runtimes from simctl
+				info.devicetypes.forEach(function (deviceType) {
+					if (!deviceTypeLookup[deviceType.identifier]) {
+						deviceTypeLookup[deviceType.identifier] = {
+							name:          deviceType.name,
+							model:         deviceType.model,
+							supportsWatch: deviceType.supportsWatch,
+							xcodeId:       xcodeInfo.selectedXcode.version + ':' + xcodeInfo.selectedXcode.build
+						};
+					}
+				});
 				info.runtimes.forEach(function (runtime) {
-					simctlRuntimes[runtime.identifier] = runtime;
+					if (!runtimeLookup[runtime.identifier]) {
+						runtimeLookup[runtime.identifier] = {
+							name:      runtime.name,
+							version:   runtime.version,
+							simctl:    xcodeInfo.selectedXcode.executables.simctl,
+							simulator: xcodeInfo.selectedXcode.executables[/watch/i.test(runtime.name) ? 'watchsimulator' : 'simulator'],
+							xcodeId:   xcodeInfo.selectedXcode.version + ':' + xcodeInfo.selectedXcode.build
+						};
+					}
 				});
 
 				var coreSimDir = appc.fs.resolvePath('~/Library/Developer/CoreSimulator/Devices');
+				var familyRE = /^(iphone|ipad|ios|watch|watchos)$/;
+
 				Object.keys(info.devices).forEach(function (type) {
 					info.devices[type].forEach(function (device) {
 						var plist = readPlist(path.join(coreSimDir, device.udid, 'device.plist'));
@@ -194,81 +241,77 @@ function detect(options, callback) {
 							return;
 						}
 
-						xcodeIds.forEach(function (id) {
-							var xc = xcodeInfo.xcode[id],
-								deviceType = xc.simDeviceTypes[plist.deviceType],
-								runtime = simctlRuntimes[plist.runtime];
+						var deviceType = deviceTypeLookup[plist.deviceType];
+						var runtime = runtimeLookup[plist.runtime];
 
-							// This code finds the sim runtime and builds the list of associated
-							// iOS SDKs which may be different based which Xcode's simctl is run.
-							// For example, sim runtime 10.3 is associated with iOS 10.3 and 10.3.1.
-							// Because of this, we define the same simulator for each associated
-							// iOS SDK version.
-							if (!runtime) {
-								runtime = xc.simRuntimes[plist.runtime];
-								if (runtime) {
-									runtime.versions = [ runtime.version ];
-								}
-							} else {
-								runtime.versions = [ runtime.version ];
-								if (xc.simRuntimes[plist.runtime]) {
-									var ver = xc.simRuntimes[plist.runtime].version;
-									if (ver !== runtime.version) {
-										runtime.versions.push(ver);
-									}
-								}
+						if (!deviceType || !runtime) {
+							// we have no idea what this simulator is nor are there any Xcodes
+							// capable of running it
+							return;
+						}
+
+						var family = deviceType.model && deviceType.model.replace(/[\W0-9]/g, '').toLowerCase();
+						if (!family || !familyRE.test(family)) {
+							// unsupported, could be an Apple TV device
+							return;
+						}
+						var type = family === 'iphone' || family === 'ipad' ? 'ios' : 'watchos';
+
+						// This code finds the sim runtime and builds the list of associated
+						// iOS SDKs which may be different based which Xcode's simctl is run.
+						// For example, sim runtime 10.3 is associated with iOS 10.3 and 10.3.1.
+						// Because of this, we define the same simulator for each associated
+						// iOS SDK version.
+						runtime.versions = [ runtime.version ];
+						if (runtimeLookup[plist.runtime]) {
+							var ver = runtimeLookup[plist.runtime].version;
+							if (ver !== runtime.version) {
+								runtime.versions.push(ver);
 							}
+						}
 
-							if (!deviceType || !runtime) {
-								// wrong xcode, skip
-								return;
-							}
+						// for each runtime iOS SDK version, define the simulator
+						runtime.versions.forEach(function (runtimeVersion) {
+							var sim;
 
-							var family = deviceType.model.replace(/[\W0-9]/g, '').toLowerCase(),
-								type = family === 'iphone' || family === 'ipad' ? 'ios' : 'watchos';
-
-							// for each runtime iOS SDK version, define the simulator
-							runtime.versions.forEach(function (runtimeVersion) {
-								var sim;
-
-								results.simulators[type][runtimeVersion] || (results.simulators[type][runtimeVersion] = []);
-								results.simulators[type][runtimeVersion].some(function (s) {
-									if (s.udid === plist.UDID) {
-										sim = s;
-										return true;
-									}
-								});
-
-								if (!sim) {
-									results.simulators[type][runtimeVersion].push(sim = {
-										udid:           plist.UDID,
-										name:           plist.name,
-										version:        runtimeVersion,
-										type:           type,
-										isAvailable:    (device.isAvailable || device.availability === '(available)') && !device.availabilityError,
-
-										deviceType:     plist.deviceType,
-										deviceName:     deviceType.name,
-										deviceDir:      path.join(coreSimDir, device.udid),
-										model:          deviceType.model,
-										family:         family,
-										supportsXcode:  {},
-										supportsWatch:  {},
-										watchCompanion: {},
-
-										runtime:        plist.runtime,
-										runtimeName:    runtime.name,
-
-										systemLog:      appc.fs.resolvePath('~/Library/Logs/CoreSimulator/' + device.udid + '/system.log'),
-										dataDir:        path.join(coreSimDir, device.udid, 'data')
-									});
-								}
-
-								sim.supportsXcode[id] = true;
-								if (type === 'ios') {
-									sim.supportsWatch[id] = deviceType.supportsWatch;
+							results.simulators[type][runtimeVersion] || (results.simulators[type][runtimeVersion] = []);
+							results.simulators[type][runtimeVersion].some(function (s) {
+								if (s.udid === plist.UDID) {
+									sim = s;
+									return true;
 								}
 							});
+
+							if (!sim) {
+								results.simulators[type][runtimeVersion].push(sim = {
+									udid:           plist.UDID,
+									name:           plist.name,
+									version:        runtimeVersion,
+									type:           type,
+									simctl:         runtime.simctl,
+									simulator:      runtime.simulator,
+
+									deviceType:     plist.deviceType,
+									deviceName:     deviceType.name,
+									deviceDir:      path.join(coreSimDir, device.udid),
+									model:          deviceType.model,
+									family:         family,
+									supportsXcode:  {},
+									supportsWatch:  {},
+									watchCompanion: {},
+
+									runtime:        plist.runtime,
+									runtimeName:    runtime.name,
+
+									systemLog:      appc.fs.resolvePath('~/Library/Logs/CoreSimulator/' + device.udid + '/system.log'),
+									dataDir:        path.join(coreSimDir, device.udid, 'data')
+								});
+							}
+
+							sim.supportsXcode[runtime.xcodeId] = true;
+							if (type === 'ios') {
+								sim.supportsWatch[runtime.xcodeId] = deviceType.supportsWatch;
+							}
 						});
 					});
 				});
@@ -276,22 +319,26 @@ function detect(options, callback) {
 				// this is pretty nasty, but necessary...
 				// basically this will populate the watchCompanion property for each iOS Simulator
 				// so that it makes choosing simulator pairs way easier
-				Object.keys(results.simulators.ios).forEach(function (iosSimVersion) {
-					results.simulators.ios[iosSimVersion].forEach(function (iosSim) {
-						Object.keys(iosSim.supportsWatch).forEach(function (xcodeId) {
+				Object.keys(results.simulators.ios).forEach(function (iosSimVersion) { // 13.0
+					results.simulators.ios[iosSimVersion].forEach(function (iosSim) { // sim handle
+						Object.keys(iosSim.supportsWatch).forEach(function (xcodeId) { // 11.0:11A419c
 							if (iosSim.supportsWatch[xcodeId]) {
 								var xc = xcodeInfo.xcode[xcodeId];
-								Object.keys(xc.simDevicePairs).forEach(function (iOSRange) {
+								Object.keys(xc.simDevicePairs).forEach(function (iOSRange) { // 13.x
 									if (appc.version.satisfies(iosSim.version, iOSRange)) {
-										Object.keys(xc.simDevicePairs[iOSRange]).forEach(function (watchOSRange) {
-											Object.keys(results.simulators.watchos).forEach(function (watchosSDK) {
-												results.simulators.watchos[watchosSDK].forEach(function (watchSim) {
-													if (appc.version.satisfies(watchSim.version, watchOSRange)) {
-														iosSim.watchCompanion[xcodeId] || (iosSim.watchCompanion[xcodeId] = {});
-														iosSim.watchCompanion[xcodeId][watchSim.udid] = watchSim;
+										Object.keys(xc.simDevicePairs[iOSRange]).forEach(function (watchOSRange) { // 6.x
+											if (xc.simDevicePairs[iOSRange][watchOSRange]) {
+												Object.keys(results.simulators.watchos).forEach(function (watchosSDK) { // 6.x
+													if (appc.version.satisfies(watchosSDK, watchOSRange)) {
+														results.simulators.watchos[watchosSDK].forEach(function (watchSim) { // watch sim handle
+															if (appc.version.satisfies(watchSim.version, watchOSRange)) {
+																iosSim.watchCompanion[xcodeId] || (iosSim.watchCompanion[xcodeId] = {});
+																iosSim.watchCompanion[xcodeId][watchSim.udid] = watchSim;
+															}
+														});
 													}
 												});
-											});
+											}
 										});
 									}
 								});
@@ -433,6 +480,47 @@ function findSimulators(options, callback) {
 			return callback(err);
 		}
 
+		function compareXcodes(a, b) {
+			var v1 = xcodeInfo.xcode[a].version;
+			var v2 = xcodeInfo.xcode[b].version;
+			if (options.iosVersion && appc.version.eq(options.iosVersion, v1)) {
+				return -1;
+			}
+			if (options.iosVersion && appc.version.eq(options.iosVersion, v2)) {
+				return 1;
+			}
+			if (xcodeInfo.xcode[a].selected) {
+				return -1;
+			}
+			if (xcodeInfo.xcode[b].selected) {
+				return 1;
+			}
+			return appc.version.gt(v1, v2) ? -1 : appc.version.eq(v1, v2) ? 0 : 1;
+		}
+
+		// find an Xcode installation that matches the iOS SDK or fall back to the selected Xcode or the latest
+		var xcodeIds = Object
+			.keys(xcodeInfo.xcode)
+			.filter(function (id) {
+				if (!xcodeInfo.xcode[id].supported) {
+					return false;
+				}
+				if (options.iosVersion && !xcodeInfo.xcode[id].sdks.some(function (ver) { return appc.version.eq(ver, options.iosVersion); })) {
+					return false;
+				}
+				return true;
+			})
+			.sort(compareXcodes);
+		if (!xcodeIds.length) {
+			if (options.iosVersion) {
+				return callback(new Error(__('Unable to find any Xcode installations that supports iOS SDK %s.', options.iosVersion)));
+			} else {
+				return callback(new Error(__('Unable to find any supported Xcode installations. Please install the latest Xcode.')));
+			}
+		}
+		var xcodeId = xcodeIds[0];
+		var selectedXcode = xcodeInfo.xcode[xcodeId];
+
 		// detect the simulators
 		detect(options, function (err, simInfo) {
 			if (err) {
@@ -441,8 +529,7 @@ function findSimulators(options, callback) {
 
 			var logger = typeof options.logger === 'function' ? options.logger : function () {},
 				simHandle = options.simHandleOrUDID instanceof SimHandle ? options.simHandleOrUDID : null,
-				watchSimHandle = options.watchHandleOrUDID instanceof SimHandle ? options.watchHandleOrUDID : null,
-				selectedXcode;
+				watchSimHandle = options.watchHandleOrUDID instanceof SimHandle ? options.watchHandleOrUDID : null;
 
 			if (options.simHandleOrUDID) {
 				// validate the udid
@@ -471,109 +558,55 @@ function findSimulators(options, callback) {
 					return callback(new Error(__('The selected iOS %s Simulator is less than the minimum iOS version %s.', simHandle.version, options.minIosVersion)));
 				}
 
-				if (!simHandle.isAvailable) {
-					return callback(new Error(__('The specified iOS Simulator with the UDID "%s" is not available.', simHandle.udid)));
-				}
-
 				if (options.watchAppBeingInstalled) {
-					var xcodeId = Object
+					var watchXcodeId = Object
 						.keys(simHandle.watchCompanion)
 						.filter(function (xcodeId) {
 							return xcodeInfo.xcode[xcodeId].supported;
 						})
-						.sort(function (a, b) {
-							var v1 = xcodeInfo.xcode[a].version;
-							var v2 = xcodeInfo.xcode[b].version;
-							return xcodeInfo.xcode[a].selected || appc.version.lt(v1, v2) ? -1 : appc.version.eq(v1, v2) ? 0 : 1;
-						})
+						.sort(compareXcodes)
 						.pop();
 
-					if (!xcodeId) {
+					if (!watchXcodeId) {
 						return callback(new Error(__('Unable to find any Watch Simulators that can be paired with the specified iOS Simulator %s.', simHandle.udid)));
 					}
 
-					if (options.watchHandleOrUDID) {
-						if (!(options.watchHandleOrUDID instanceof SimHandle)) {
-							logger(__('Watch app present, validating Watch Simulator UDID %s', options.watchHandleOrUDID));
-
-							Object.keys(simInfo.simulators.watchos).some(function (ver) {
-								return simInfo.simulators.watchos[ver].some(function (sim) {
-									if (sim.udid === options.watchHandleOrUDID) {
-										logger(__('Found Watch Simulator UDID %s', options.watchHandleOrUDID));
-										watchSimHandle = new SimHandle(sim);
-										return true;
-									}
-								});
-							});
-
-							if (!watchSimHandle) {
-								return callback(new Error(__('Unable to find a Watch Simulator with the UDID "%s".', options.watchHandleOrUDID)));
-							}
-						}
-
-						if (!watchSimHandle.isAvailable) {
-							return callback(new Error(__('The specified Watch Simulator with the UDID "%s" is not available.', watchSimHandle.udid)));
-						}
-					} else {
+					if (!options.watchHandleOrUDID) {
 						logger(__('Watch app present, autoselecting a Watch Simulator'));
 
-						var companions = simHandle.watchCompanion[xcodeId];
-
-						Object.keys(companions)
+						var companions = simHandle.watchCompanion[watchXcodeId];
+						var companionUDID = Object.keys(companions)
 							.sort(function (a, b) {
-								return companions[a].model < companions[b].model ? 1 : companions[a].model > companions[b].model ? -1 : 0;
+								return companions[a].model.localeCompare(companions[b].model);
 							})
-							.some(function (watchUDID) {
-								if (companions[watchUDID].isAvailable) {
-									watchSimHandle = new SimHandle(companions[watchUDID]);
-									return true;
-								}
-							});
+							.pop();
+
+						watchSimHandle = new SimHandle(companions[companionUDID]);
 
 						if (!watchSimHandle) {
 							return callback(new Error(__('Specified iOS Simulator "%s" does not support Watch apps.', options.simHandleOrUDID)));
 						}
-					}
+					} else if (!(options.watchHandleOrUDID instanceof SimHandle)) {
+						logger(__('Watch app present, validating Watch Simulator UDID %s', options.watchHandleOrUDID));
 
-					selectedXcode = xcodeInfo.xcode[xcodeId];
-				} else {
-					// no watch sim, just an ios sim
-					// find the version of Xcode
-					var xcodeId = Object
-						.keys(simHandle.supportsXcode)
-						.filter(function (id) {
-							if (!simHandle.supportsXcode[id]) {
-								return false;
-							}
-							if (!xcodeInfo.xcode[id].supported) {
-								return false;
-							}
-							if (options.iosVersion && xcodeInfo.xcode[id].sdks.indexOf(options.iosVersion) === -1) {
-								return false;
-							}
-							return true;
-						})
-						.sort(function (a, b) {
-							var v1 = xcodeInfo.xcode[a].version;
-							var v2 = xcodeInfo.xcode[b].version;
-							return xcodeInfo.xcode[a].selected || appc.version.lt(v1, v2) ? -1 : appc.version.eq(v1, v2) ? 0 : 1;
-						})
-						.pop();
+						Object.keys(simInfo.simulators.watchos).some(function (ver) {
+							return simInfo.simulators.watchos[ver].some(function (sim) {
+								if (sim.udid === options.watchHandleOrUDID) {
+									logger(__('Found Watch Simulator UDID %s', options.watchHandleOrUDID));
+									watchSimHandle = new SimHandle(sim);
+									return true;
+								}
+							});
+						});
 
-					selectedXcode = xcodeInfo.xcode[xcodeId];
-				}
-
-				if (!selectedXcode) {
-					if (options.iosVersion) {
-						return callback(new Error(__('Unable to find any Xcode installations that support both iOS %s and iOS Simulator %s.', options.iosVersion, options.simHandleOrUDID)));
-					} else if (options.minIosVersion) {
-						return callback(new Error(__('Unable to find any Xcode installations that support at least iOS %s and iOS Simulator %s.', options.minIosVersion, options.simHandleOrUDID)));
-					} else {
-						return callback(new Error(__('Unable to find any supported Xcode installations. Please install the latest Xcode.')));
+						if (!watchSimHandle) {
+							return callback(new Error(__('Unable to find a Watch Simulator with the UDID "%s".', options.watchHandleOrUDID)));
+						}
 					}
 				}
 
-				if (watchSimHandle && !simHandle.watchCompanion[selectedXcode.version + ':' + selectedXcode.build][watchSimHandle.udid]) {
+				// double check
+				if (watchSimHandle && !simHandle.watchCompanion[watchXcodeId][watchSimHandle.udid]) {
 					return callback(new Error(__('Specified Watch Simulator "%s" is not compatible with iOS Simulator "%s".', watchSimHandle.udid, simHandle.udid)));
 				}
 
@@ -616,115 +649,69 @@ function findSimulators(options, callback) {
 					if (!watchSimHandle) {
 						return callback(new Error(__('Unable to find a Watch Simulator with the UDID "%s".', options.watchHandleOrUDID)));
 					}
-
-					if (!watchSimHandle.isAvailable) {
-						return callback(new Error(__('The specified Watch Simulator with the UDID "%s" is not available.', watchSimHandle.udid)));
-					}
 				}
 
 				// pick one
-				var xcodeIds = Object
-					.keys(xcodeInfo.xcode)
-					.filter(function (ver) {
-						if (!xcodeInfo.xcode[ver].supported) {
-							return false;
-						}
-						if (watchSimHandle && !watchSimHandle.supportsXcode[ver]) {
-							return false;
-						}
-						if (options.iosVersion && xcodeInfo.xcode[ver].sdks.indexOf(options.iosVersion) === -1) {
-							return false;
-						}
-						return true;
-					})
-					.sort(function (a, b) {
-						var v1 = xcodeInfo.xcode[a].version;
-						var v2 = xcodeInfo.xcode[b].version;
-						return xcodeInfo.xcode[a].selected || appc.version.lt(v1, v2) ? -1 : appc.version.eq(v1, v2) ? 0 : 1;
-					})
-					.reverse();
+				logger(__('Scanning Xcodes: %s', xcodeIds.join(' ')));
 
-				if (xcodeIds.length) {
-					logger(__('Scanning Xcodes: %s', xcodeIds.join(' ')));
+				// loop through xcodes
+				for (var i = 0; !simHandle && i < xcodeIds.length; i++) {
+					var xc = xcodeInfo.xcode[xcodeIds[i]];
+					var simVers = xc.sims.sort().reverse();
 
-					// loop through xcodes
-					for (var i = 0; !simHandle && i < xcodeIds.length; i++) {
-						var xcodeId = xcodeIds[i],
-							xc = xcodeInfo.xcode[xcodeId],
-							simVers = xc.sims.sort().reverse();
+					logger(__('Scanning Xcode %s sims: %s', xcodeIds[i], simVers.join(', ')));
 
-						logger(__('Scanning Xcode %s sims: %s', xcodeIds[i], simVers.join(', ')));
+					// loop through each xcode simulators
+					for (var j = 0; !simHandle && j < simVers.length; j++) {
+						if ((!options.simVersion || simVers[j] === options.simVersion) &&
+							(!options.minIosVersion || appc.version.gte(simVers[j], options.minIosVersion)) &&
+							simInfo.simulators.ios[simVers[j]]
+						) {
+							var sims = simInfo.simulators.ios[simVers[j]].sort(compareSims).reverse();
 
-						// loop through each xcode simulators
-						for (var j = 0; !simHandle && j < simVers.length; j++) {
-							if ((!options.simVersion || simVers[j] === options.simVersion) &&
-								(!options.minIosVersion || appc.version.gte(simVers[j], options.minIosVersion)) &&
-								simInfo.simulators.ios[simVers[j]]
-							) {
-								var sims = simInfo.simulators.ios[simVers[j]].sort(compareSims).reverse();
+							// loop through each simulator
+							for (var k = 0; !simHandle && k < sims.length; k++) {
+								if (options.simType && sims[k].family !== options.simType) {
+									continue;
+								}
 
-								// loop through each simulator
-								for (var k = 0; !simHandle && k < sims.length; k++) {
-									if (options.simType && sims[k].family !== options.simType) {
-										continue;
-									}
-
-									if (!sims[k].isAvailable) {
-										continue;
-									}
-
-									// if we're installing a watch extension, make sure we pick a simulator that supports the watch
-									if (options.watchAppBeingInstalled) {
-										if (watchSimHandle) {
-											Object.keys(sims[k].supportsWatch).forEach(function (xcodeVer) {
-												if (watchSimHandle.isAvailable && watchSimHandle.supportsXcode[xcodeVer]) {
-													selectedXcode = xcodeInfo.xcode[xcodeVer];
-													simHandle = new SimHandle(sims[k]);
-													return true;
-												}
-											});
-										} else if (sims[k].supportsWatch[xcodeIds[i]]) {
-											// make sure this version of Xcode has a watch simulator that supports the watch app version
-											xc.watchos.sims.some(function (ver) {
-												if (appc.version.gte(ver, options.watchMinOSVersion) && simInfo.simulators.watchos[ver]) {
-													simHandle = new SimHandle(sims[k]);
-													selectedXcode = xcodeInfo.xcode[xcodeIds[i]];
-													const watchSim = simInfo.simulators.watchos[ver].sort(compareSims).reverse()[0];
-													if (watchSim.isAvailable) {
-														watchSimHandle = new SimHandle(watchSim);
-														return true;
-													}
-												}
-											});
-										}
-									} else {
-										// no watch app
-										logger(__('No watch app being installed, so picking first Simulator'));
-										simHandle = new SimHandle(sims[k]);
-
-										// fallback to the newest supported Xcode version
-										xcodeIds.some(function (id) {
-											if (simHandle.supportsXcode[id]) {
-												selectedXcode = xcodeInfo.xcode[id];
+								// if we're installing a watch extension, make sure we pick a simulator that supports the watch
+								if (options.watchAppBeingInstalled) {
+									if (watchSimHandle) {
+										Object.keys(sims[k].supportsWatch).forEach(function (xcodeVer) {
+											if (watchSimHandle.supportsXcode[xcodeVer]) {
+												selectedXcode = xcodeInfo.xcode[xcodeVer];
+												simHandle = new SimHandle(sims[k]);
+												return true;
+											}
+										});
+									} else if (sims[k].supportsWatch[xcodeIds[i]]) {
+										// make sure this version of Xcode has a watch simulator that supports the watch app version
+										xc.watchos.sims.some(function (ver) {
+											if (appc.version.gte(ver, options.watchMinOSVersion) && simInfo.simulators.watchos[ver]) {
+												simHandle = new SimHandle(sims[k]);
+												selectedXcode = xcodeInfo.xcode[xcodeIds[i]];
+												const watchSim = simInfo.simulators.watchos[ver].sort(compareSims).reverse()[0];
+												watchSimHandle = new SimHandle(watchSim);
 												return true;
 											}
 										});
 									}
+								} else {
+									// no watch app
+									logger(__('No watch app being installed, so picking first Simulator'));
+									simHandle = new SimHandle(sims[k]);
+
+									// fallback to the newest supported Xcode version
+									xcodeIds.some(function (id) {
+										if (simHandle.supportsXcode[id]) {
+											selectedXcode = xcodeInfo.xcode[id];
+											return true;
+										}
+									});
 								}
 							}
 						}
-					}
-				}
-
-				if (!selectedXcode) {
-					if (options.iosVersion && watchSimHandle) {
-						return callback(new Error(__('Unable to find any Xcode installations that supports iOS Simulator %s and watchOS Simulator %s.', options.iosVersion, watchSimHandle.udid)));
-					} else if (options.iosVersion) {
-						return callback(new Error(__('Unable to find any Xcode installations that supports iOS Simulator %s.', options.iosVersion)));
-					} else if (options.minIosVersion) {
-						return callback(new Error(__('Unable to find any Xcode installations that supports at least iOS %s.', options.minIosVersion)));
-					} else {
-						return callback(new Error(__('Unable to find any supported Xcode installations. Please install the latest Xcode.')));
 					}
 				}
 
@@ -752,13 +739,6 @@ function findSimulators(options, callback) {
 					logger(__('  watchOS = %s', watchSimHandle.version));
 				}
 				logger(__('Autoselected Xcode: %s', selectedXcode.version));
-			}
-
-			simHandle.simulator = selectedXcode.executables.simulator;
-			simHandle.simctl = selectedXcode.executables.simctl;
-			if (watchSimHandle) {
-				watchSimHandle.simulator = selectedXcode.executables.watchsimulator;
-				watchSimHandle.simctl = selectedXcode.executables.simctl;
 			}
 
 			callback(null, simHandle, watchSimHandle, selectedXcode, simInfo, xcodeInfo);
@@ -1004,11 +984,6 @@ function launch(simHandleOrUDID, options, callback) {
 									return next(new Error(__('Unable to find simulator %s', handle.udid)));
 								}
 
-								if (sim.isAvailable === false && sim.availability !== '(available)') {
-									// this should never happen
-									return next(new Error(__('Simulator is not available')));
-								}
-
 								function waitToBoot() {
 									emitter.emit('log-debug', __('Waiting for simulator to boot...'));
 									simctl.waitUntilBooted({ simctl: handle.simctl, udid: handle.udid, timeout: 30000 }, function (err, _booted) {
@@ -1095,8 +1070,7 @@ function launch(simHandleOrUDID, options, callback) {
 							fs.writeFileSync(handle.systemLog, '');
 						}
 
-						var smsRegExp = / SpringBoard\[\d+\]\: SMS Plugin initialized/,
-							systemLogRegExp = new RegExp(' ' + handle.appName + '\\[(\\d+)\\]: (.*)'),
+						var systemLogRegExp = new RegExp(' ' + handle.appName + '\\[(\\d+)\\]: (.*)'),
 							watchLogMsgRegExp = handle.type === 'ios' && watchAppId ? new RegExp('companionappd\\[(\\d+)\\]: \\((.+)\\) WatchKit: application \\(' + watchAppId + '\\),?\w*(.*)') : null,
 							xcode73WatchLogMsgRegExp = handle.type === 'ios' && watchAppId ? new RegExp('Installation of ' + watchAppId + ' (.*).') : null,
 							watchInstallRegExp = /install status: (\d+), message: (.*)$/,
@@ -1300,7 +1274,7 @@ function launch(simHandleOrUDID, options, callback) {
 						return next();
 					}
 
-					simctl.list({ simctl: selectedXcode.executables.simctl }, function (err, info) {
+					simctl.list({ simctl: simHandle.simctl }, function (err, info) {
 						if (err) {
 							return next(err);
 						}
@@ -1313,7 +1287,7 @@ function launch(simHandleOrUDID, options, callback) {
 
 						if (found) {
 							emitter.emit('log-debug', __('Activating iOS and watchOS simulator pair: %s', found.udid));
-							return simctl.activatePair({ simctl: selectedXcode.executables.simctl, udid: found.udid }, next);
+							return simctl.activatePair({ simctl: simHandle.simctl, udid: found.udid }, next);
 						}
 
 						// not paired... check if our watch sim is paired with another ios sim
@@ -1328,13 +1302,13 @@ function launch(simHandleOrUDID, options, callback) {
 						if (!unpairFromIosSimUdid) {
 							// not paired, try to pair
 							emitter.emit('log-debug', __('Pairing iOS and watchOS simulator pair: %s -> %s', watchSimHandle.udid, simHandle.udid));
-							return simctl.pairAndActivate({ simctl: selectedXcode.executables.simctl, simUdid: simHandle.udid, watchSimUdid: watchSimHandle.udid }, next);
+							return simctl.pairAndActivate({ simctl: simHandle.simctl, simUdid: simHandle.udid, watchSimUdid: watchSimHandle.udid }, next);
 						}
 
 						// try to unpair
 						found = info.iosSimToWatchSimToPair[unpairFromIosSimUdid][watchSimHandle.udid];
 						emitter.emit('log-debug', __('Unpairing iOS and watchOS simulator pair: %s', found.udid));
-						simctl.unpair({ simctl: selectedXcode.executables.simctl, udid: found.udid }, function (err) {
+						simctl.unpair({ simctl: simHandle.simctl, udid: found.udid }, function (err) {
 							if (err && err.code !== 666) {
 								return next(err);
 							}
@@ -1342,7 +1316,7 @@ function launch(simHandleOrUDID, options, callback) {
 							if (!err) {
 								// unpair succeeded
 								emitter.emit('log-debug', __('Pairing iOS and watchOS simulator pair: %s -> %s', watchSimHandle.udid, simHandle.udid));
-								return simctl.pairAndActivate({ simctl: selectedXcode.executables.simctl, simUdid: simHandle.udid, watchSimUdid: watchSimHandle.udid }, next);
+								return simctl.pairAndActivate({ simctl: simHandle.simctl, simUdid: simHandle.udid, watchSimUdid: watchSimHandle.udid }, next);
 							}
 
 							// at this point we have a watch sim that we can't unpair from the ios sim,
@@ -1367,12 +1341,10 @@ function launch(simHandleOrUDID, options, callback) {
 								function () { return candidates.length; },
 								function (cb) {
 									newWatchSimHandle = new SimHandle(candidates.shift());
-									newWatchSimHandle.simulator = selectedXcode.executables.watchsimulator;
-									newWatchSimHandle.simctl = selectedXcode.executables.simctl;
 
 									emitter.emit('log-debug', __('Trying watch sim %s [%s]', newWatchSimHandle.name, newWatchSimHandle.udid));
 									emitter.emit('log-debug', __('Pairing iOS and watchOS simulator pair: %s -> %s', newWatchSimHandle.udid, simHandle.udid));
-									simctl.pairAndActivate({ simctl: selectedXcode.executables.simctl, simUdid: simHandle.udid, watchSimUdid: newWatchSimHandle.udid }, function (err) {
+									simctl.pairAndActivate({ simctl: simHandle.simctl, simUdid: simHandle.udid, watchSimUdid: newWatchSimHandle.udid }, function (err) {
 										if (err) {
 											emitter.emit('log-debug', __('Pairing failed, trying another watch simulator'));
 											newWatchSimHandle = null;
@@ -1391,7 +1363,7 @@ function launch(simHandleOrUDID, options, callback) {
 									var name = m ? (m[1] + ' ' + ((~~m[2] || 1) + 1)) : (watchSimHandle.name + ' [Titanium]');
 									emitter.emit('log-debug', __('Creating a new watch simulator: %s', name));
 									simctl.create({
-										simctl: selectedXcode.executables.simctl,
+										simctl: simHandle.simctl,
 										name: name,
 										deviceType: watchSimHandle.deviceType,
 										runtime: watchSimHandle.runtime
@@ -1405,8 +1377,6 @@ function launch(simHandleOrUDID, options, callback) {
 											simInfo.simulators.watchos[watchSimHandle.version].some(function (sim) {
 												if (sim.udid === udid) {
 													watchSimHandle = new SimHandle(sim);
-													watchSimHandle.simulator = selectedXcode.executables.watchsimulator;
-													watchSimHandle.simctl = selectedXcode.executables.simctl;
 													found = true;
 													return true;
 												}
@@ -1417,7 +1387,7 @@ function launch(simHandleOrUDID, options, callback) {
 												return next(new Error(__('Unable to find the watch simulator %s that was just created', udid)));
 											}
 
-											simctl.pairAndActivate({ simctl: selectedXcode.executables.simctl, simUdid: simHandle.udid, watchSimUdid: watchSimHandle.udid }, next);
+											simctl.pairAndActivate({ simctl: simHandle.simctl, simUdid: simHandle.udid, watchSimUdid: watchSimHandle.udid }, next);
 										});
 									});
 								}
@@ -1553,7 +1523,7 @@ function launch(simHandleOrUDID, options, callback) {
 						return next();
 					}
 					emitter.emit('log-debug', __('Uninstalling the app'));
-					simctl.uninstall({ simctl: selectedXcode.executables.simctl, udid: simHandle.udid, appId: appId }, next);
+					simctl.uninstall({ simctl: simHandle.simctl, udid: simHandle.udid, appId: appId }, next);
 				},
 
 				function installApp(next) {
@@ -1563,7 +1533,7 @@ function launch(simHandleOrUDID, options, callback) {
 					simHandle.installing = true;
 					watchSimHandle && (watchSimHandle.installing = true);
 					emitter.emit('log-debug', __('Installing the app'));
-					simctl.install({ simctl: selectedXcode.executables.simctl, udid: simHandle.udid, appPath: options.appPath }, next);
+					simctl.install({ simctl: simHandle.simctl, udid: simHandle.udid, appPath: options.appPath }, next);
 				},
 
 				function installWatchApp(next) {
@@ -1579,7 +1549,7 @@ function launch(simHandleOrUDID, options, callback) {
 						try {
 							if (fs.statSync(watchAppDir).isDirectory() && fs.statSync(path.join(watchAppDir, 'Info.plist')).isFile()) {
 								emitter.emit('log-debug', __('Installing the watch app: %s', path.parse(name).name));
-								return simctl.install({ simctl: selectedXcode.executables.simctl, udid: watchSimHandle.udid, appPath: watchAppDir }, cb);
+								return simctl.install({ simctl: simHandle.simctl, udid: watchSimHandle.udid, appPath: watchAppDir }, cb);
 							}
 						} catch (e) {}
 
@@ -1630,7 +1600,7 @@ function launch(simHandleOrUDID, options, callback) {
 						// to show a black screen which will flash for a second before main app launches instead
 						// of the main app flashing for a second before the screen turned black.
 						simctl.launch({
-							simctl: selectedXcode.executables.simctl,
+							simctl: simHandle.simctl,
 							udid: appc.version.gte(selectedXcode.version, '7.0') ? watchSimHandle.udid : simHandle.udid,
 							appId: watchAppId
 						}, function (err) {
@@ -1651,7 +1621,7 @@ function launch(simHandleOrUDID, options, callback) {
 						}
 
 						simctl.launch({
-							simctl: selectedXcode.executables.simctl,
+							simctl: simHandle.simctl,
 							udid: simHandle.udid,
 							appId: appId
 						}, function (err) {

--- a/lib/simulator.js
+++ b/lib/simulator.js
@@ -203,7 +203,7 @@ function detect(options, callback) {
 				});
 			});
 
-			simctl.list({ simctl: xcodeInfo.selectedXcode.executables.simctl }, function (err, info) {
+			list(options, function (err, info) {
 				if (err) {
 					return callback(err);
 				}
@@ -1203,11 +1203,11 @@ function launch(simHandleOrUDID, options, callback) {
 						async.whilst(
 							function () { return !booted; },
 							function (cb) {
-								simctl.list({ simctl: handle.simctl }, function (err, info) {
+								list(options, function (err, info) {
 									Object.keys(info.devices).some(function (type) {
 										return info.devices[type].some(function (sim) {
 											if (sim.udid === handle.udid) {
-												if (/^booted$/i.test(sim.state) && (sim.isAvailable || sim.availability === '(available)')) {
+												if (/^booted$/i.test(sim.state)) {
 													booted = true;
 												}
 												return true;
@@ -1274,7 +1274,7 @@ function launch(simHandleOrUDID, options, callback) {
 						return next();
 					}
 
-					simctl.list({ simctl: simHandle.simctl }, function (err, info) {
+					list(options, function (err, info) {
 						if (err) {
 							return next(err);
 						}
@@ -1786,6 +1786,76 @@ function getRunningSimulatorDevices(callback) {
 		}
 
 		callback(null, results);
+	});
+}
+
+/**
+ * Runs `simctl list` for each Xcode and merges the results. Note that the `isAvailable` property
+ * cannot be trusted.
+ *
+ * @param {Object} options - Various Xcode detect options.
+ * @param {Function} callback - A function to call with the info.
+ */
+function list(options, callback) {
+	xcode.detect(options, function (err, xcodeInfo) {
+		if (err) {
+			return callback(err);
+		}
+
+		const results = {
+			devicetypes: [],
+			runtimes: [],
+			devices: {},
+			pairs: {}
+		};
+
+		const xcodes = Object.keys(xcodeInfo.xcode).filter(function (ver) { return xcodeInfo.xcode[ver].supported; });
+
+		async.eachSeries(xcodes, function (xcodeId, next) {
+			var xcode = xcodeInfo.xcode[xcodeId];
+			simctl.list({ simctl: xcode.executables.simctl }, function (err, info) {
+				if (err) {
+					return next(err);
+				}
+
+				info.devicetypes.forEach(function (dt) {
+					if (!results.runtimes.some(function (d) { return d.name === dt.name && d.identifier === dt.identifier; })) {
+						results.devicetypes.push(dt);
+					}
+				});
+
+				info.runtimes.forEach(function (rt) {
+					if (!results.runtimes.some(function (r) { return r.name === rt.name && r.version === rt.version && r.identifier === rt.identifier; })) {
+						results.runtimes.push(rt);
+					}
+				});
+
+				Object.keys(info.devices).forEach(function (rt) {
+					if (!results.devices[rt]) {
+						results.devices[rt] = [];
+					}
+					info.devices[rt].forEach(function (dev) {
+						if (!results.devices[rt].some(function (d) { return d.udid === dev.udid; })) {
+							results.devices[rt].push(dev);
+						}
+					});
+				});
+
+				Object.keys(info.pairs).forEach(function (udid) {
+					if (!results.pairs[udid]) {
+						results.pairs[udid] = info.pairs[udid];
+					}
+				});
+
+				next();
+			});
+		}, function (err) {
+			if (err) {
+				callback(err);
+			} else {
+				callback(null, results);
+			}
+		});
 	});
 }
 

--- a/lib/xcode.js
+++ b/lib/xcode.js
@@ -81,7 +81,7 @@ const simulatorDevicePairCompatibility = {
 			'3.x': true    // watchOS 3.x
 		},
 		'11.x': {		   // iOS 11.x
-			'>=3.2': true, // watchOS 3.2
+			'>=3.2 <4.0': true, // watchOS 3.2
 			'4.x': true    // watchOS 4.x
 		}
 	},
@@ -95,11 +95,11 @@ const simulatorDevicePairCompatibility = {
 			'3.x': true    // watchOS 3.x
 		},
 		'11.x': {		   // iOS 11.x
-			'>=3.2': true, // watchOS 3.2
+			'>=3.2 <4.0': true, // watchOS 3.2
 			'4.x': true    // watchOS 4.x
 		},
 		'12.x': {		   // iOS 12.x
-			'>=4.x': true, // watchOS 4.x
+			'4.x': true,   // watchOS 4.x
 			'5.x': true    // watchOS 5.x
 		}
 	},
@@ -109,7 +109,7 @@ const simulatorDevicePairCompatibility = {
 			'3.x': true    // watchOS 3.x
 		},
 		'11.x': {		   // iOS 11.x
-			'>=3.2': true, // watchOS 3.2
+			'>=3.2 <4.0': true, // watchOS 3.2
 			'4.x': true    // watchOS 4.x
 		},
 		'12.x': {		   // iOS 12.x

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "ioslib",
-  "version": "1.7.13",
+  "version": "1.7.14",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -10,19 +10,19 @@
       "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q=="
     },
     "adm-zip": {
-      "version": "0.4.11",
-      "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.4.11.tgz",
-      "integrity": "sha512-L8vcjDTCOIJk7wFvmlEUN7AsSb8T+2JrdP7KINBjzr24TJ5Mwj590sLu3BC7zNZowvJWa/JtPmD8eJCzdtDWjA=="
+      "version": "0.4.13",
+      "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.4.13.tgz",
+      "integrity": "sha512-fERNJX8sOXfel6qCBCMPvZLzENBEhZTzKqg6vrOW5pvoEaQuJhRU4ndTAh6lHOxn1I6jnz2NHra56ZODM751uw=="
     },
     "ajv": {
-      "version": "5.5.2",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
-      "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
+      "version": "6.10.2",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.10.2.tgz",
+      "integrity": "sha512-TXtUUEYHuaTEbLZWIKUr5pmBuhDLy+8KYtPYdcV8qC+pOZL+NKqYwvWSRrVXHn+ZmRRAu8vJTAznH7Oag6RVRw==",
       "requires": {
-        "co": "^4.6.0",
-        "fast-deep-equal": "^1.0.0",
+        "fast-deep-equal": "^2.0.1",
         "fast-json-stable-stringify": "^2.0.0",
-        "json-schema-traverse": "^0.3.0"
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
       }
     },
     "always-tail": {
@@ -73,18 +73,11 @@
       "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
     },
     "async": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/async/-/async-2.6.1.tgz",
-      "integrity": "sha512-fNEiL2+AZt6AlAw/29Cr0UDe4sRAHCpEHh54WMz+Bb7QfNcFw4h3loofyJpLeQs4Yx7yuqu/2dLgM5hKOs6HlQ==",
+      "version": "2.6.3",
+      "resolved": "https://registry.npmjs.org/async/-/async-2.6.3.tgz",
+      "integrity": "sha512-zflvls11DCy+dQWzTW2dzuilv8Z5X/pjfmZOWba6TNIVDm+2UDaJmXSOXlasHKfNBs8oo3M0aT50fDEWfKZjXg==",
       "requires": {
-        "lodash": "^4.17.10"
-      },
-      "dependencies": {
-        "lodash": {
-          "version": "4.17.10",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
-          "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg=="
-        }
+        "lodash": "^4.17.14"
       }
     },
     "asynckit": {
@@ -111,7 +104,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
       "integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
-      "optional": true,
       "requires": {
         "tweetnacl": "^0.14.3"
       }
@@ -150,14 +142,9 @@
       "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
     },
     "chownr": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.0.1.tgz",
-      "integrity": "sha1-4qdQQqlVGQi+vSW4Uj1fl2nXkYE="
-    },
-    "co": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
-      "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ="
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.2.tgz",
+      "integrity": "sha512-GkfeAQh+QNy3wquu9oIZr6SS5x7wGdSgNQvD10X3r+AZr1Oys22HW8kAmDMvNg2+Dm0TeGaEuO8gFwdBXxwO8A=="
     },
     "code-point-at": {
       "version": "1.1.0",
@@ -165,14 +152,14 @@
       "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
     },
     "colors": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/colors/-/colors-1.3.1.tgz",
-      "integrity": "sha512-jg/vxRmv430jixZrC+La5kMbUWqIg32/JsYNZb94+JEmzceYbWKTsv1OuTp+7EaqiaWRR2tPcykibwCRgclIsw=="
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/colors/-/colors-1.3.3.tgz",
+      "integrity": "sha512-mmGt/1pZqYRjMxB1axhTo16/snVZ5krrKkcmMeVKxzECMMXoCgnvTPp10QgHfcbQZw8Dq2jMNG6je4JlWU0gWg=="
     },
     "combined-stream": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.6.tgz",
-      "integrity": "sha1-cj599ugBrFYTETp+RFqbactjKBg=",
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
       "requires": {
         "delayed-stream": "~1.0.0"
       }
@@ -207,11 +194,18 @@
       }
     },
     "debug": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-      "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
+      "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
       "requires": {
-        "ms": "2.0.0"
+        "ms": "^2.1.1"
+      },
+      "dependencies": {
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+        }
       }
     },
     "deep-extend": {
@@ -243,7 +237,6 @@
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
       "integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
-      "optional": true,
       "requires": {
         "jsbn": "~0.1.0",
         "safer-buffer": "^2.1.0"
@@ -266,9 +259,9 @@
       "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU="
     },
     "fast-deep-equal": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz",
-      "integrity": "sha1-wFNHeBfIa1HaqFPIHgWbcz0CNhQ="
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
+      "integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk="
     },
     "fast-json-stable-stringify": {
       "version": "2.0.0",
@@ -281,19 +274,19 @@
       "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE="
     },
     "form-data": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.2.tgz",
-      "integrity": "sha1-SXBJi+YEwgwAXU9cI67NIda0kJk=",
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
+      "integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
       "requires": {
         "asynckit": "^0.4.0",
-        "combined-stream": "1.0.6",
+        "combined-stream": "^1.0.6",
         "mime-types": "^2.1.12"
       }
     },
     "fs-extra": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-6.0.1.tgz",
-      "integrity": "sha512-GnyIkKhhzXZUWFCaJzvyDLEEgDkPfb4/TPvJCJVuS8MWZgoSsErf++QpiAlDnKFcqhRlm+tIOcencCjyJE6ZCA==",
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.1.tgz",
+      "integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
       "requires": {
         "graceful-fs": "^4.1.2",
         "jsonfile": "^4.0.0",
@@ -301,11 +294,11 @@
       }
     },
     "fs-minipass": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-1.2.5.tgz",
-      "integrity": "sha512-JhBl0skXjUPCFH7x6x61gQxrKyXsxB5gcgePLZCwfyCGGsTISMoIeObbrvVeP6Xmyaudw4TT43qV2Gz+iyd2oQ==",
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-1.2.7.tgz",
+      "integrity": "sha512-GWSSJGFy4e9GUeCcbIkED+bgAoFyj7XF1mV8rma3QW4NIqX9Kyx79N/PF61H5udOV3aY1IaMLs6pGbH71nlCTA==",
       "requires": {
-        "minipass": "^2.2.1"
+        "minipass": "^2.6.0"
       }
     },
     "fs.realpath": {
@@ -351,9 +344,9 @@
       }
     },
     "graceful-fs": {
-      "version": "4.1.11",
-      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
-      "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg="
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.2.tgz",
+      "integrity": "sha512-IItsdsea19BoLC7ELy13q1iJFNmd7ofZH5+X/pJr90/nRoPEX0DJo1dHDbgtYWOhJhcCgMDTOw84RZ72q6lB+Q=="
     },
     "growl": {
       "version": "1.10.5",
@@ -367,11 +360,11 @@
       "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI="
     },
     "har-validator": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.0.3.tgz",
-      "integrity": "sha1-ukAsJmGU8VlW7xXg/PJCmT9qff0=",
+      "version": "5.1.3",
+      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.3.tgz",
+      "integrity": "sha512-sNvOCzEQNr/qrvJgc3UG/kD4QtlHycrzwS+6mfTrrSq97BvaYcPZZI1ZSqGSPR73Cxn4LKTD4PttRwfU7jWq5g==",
       "requires": {
-        "ajv": "^5.1.0",
+        "ajv": "^6.5.5",
         "har-schema": "^2.0.0"
       }
     },
@@ -403,17 +396,17 @@
       }
     },
     "iconv-lite": {
-      "version": "0.4.23",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.23.tgz",
-      "integrity": "sha512-neyTUVFtahjf0mB3dZT77u+8O0QB89jFdnBkd5P1JgYPbPaia3gXXOVL2fq8VyU2gMMD7SaN7QukTB/pmXYvDA==",
+      "version": "0.4.24",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
       "requires": {
         "safer-buffer": ">= 2.1.2 < 3"
       }
     },
     "ignore-walk": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/ignore-walk/-/ignore-walk-3.0.1.tgz",
-      "integrity": "sha512-DTVlMx3IYPe0/JJcYP7Gxg7ttZZu3IInhuEhbchuqneY9wWe5Ojy2mXLBaQFUQmo0AW2r3qG7m1mg86js+gnlQ==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/ignore-walk/-/ignore-walk-3.0.2.tgz",
+      "integrity": "sha512-EXyErtpHbn75ZTsOADsfx6J/FPo6/5cjev46PXrcTpd8z3BoRkXgYu9/JVqrI7tusjmwCZutGeRJeU0Wo1e4Cw==",
       "requires": {
         "minimatch": "^3.0.4"
       }
@@ -463,8 +456,7 @@
     "jsbn": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
-      "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
-      "optional": true
+      "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM="
     },
     "json-schema": {
       "version": "0.2.3",
@@ -472,9 +464,9 @@
       "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM="
     },
     "json-schema-traverse": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
-      "integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A="
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
     },
     "json-stringify-safe": {
       "version": "5.0.1",
@@ -500,17 +492,22 @@
         "verror": "1.10.0"
       }
     },
+    "lodash": {
+      "version": "4.17.15",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
+    },
     "mime-db": {
-      "version": "1.35.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.35.0.tgz",
-      "integrity": "sha512-JWT/IcCTsB0Io3AhWUMjRqucrHSPsSf2xKLaRldJVULioggvkJvggZ3VXNNSRkCddE6D+BUI4HEIZIA2OjwIvg=="
+      "version": "1.40.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.40.0.tgz",
+      "integrity": "sha512-jYdeOMPy9vnxEqFRRo6ZvTZ8d9oPb+k18PKoYNYUe2stVEBPPwsln/qWzdbmaIvnhZ9v2P+CuecK+fpUfsV2mA=="
     },
     "mime-types": {
-      "version": "2.1.19",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.19.tgz",
-      "integrity": "sha512-P1tKYHVSZ6uFo26mtnve4HQFE3koh1UWVkp8YUC+ESBHe945xWSoXuHHiGarDqcEZ+whpCDnlNw5LON0kLo+sw==",
+      "version": "2.1.24",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.24.tgz",
+      "integrity": "sha512-WaFHS3MCl5fapm3oLxU4eYDw77IQM2ACcxQ9RIxfaC3ooc6PFuBMGZZsYpvoXS5D5QTWPieo1jjLdAm3TBP3cQ==",
       "requires": {
-        "mime-db": "~1.35.0"
+        "mime-db": "1.40.0"
       }
     },
     "minimatch": {
@@ -527,18 +524,18 @@
       "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
     },
     "minipass": {
-      "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.3.3.tgz",
-      "integrity": "sha512-/jAn9/tEX4gnpyRATxgHEOV6xbcyxgT7iUnxo9Y3+OB0zX00TgKIv/2FZCf5brBbICcwbLqVv2ImjvWWrQMSYw==",
+      "version": "2.6.5",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.6.5.tgz",
+      "integrity": "sha512-ewSKOPFH9blOLXx0YSE+mbrNMBFPS+11a2b03QZ+P4LVrUHW/GAlqeYC7DBknDyMWkHzrzTpDhUvy7MUxqyrPA==",
       "requires": {
         "safe-buffer": "^5.1.2",
         "yallist": "^3.0.0"
       }
     },
     "minizlib": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-1.1.0.tgz",
-      "integrity": "sha512-4T6Ur/GctZ27nHfpt9THOdRZNgyJ9FZchYO1ceg5S8Q3DNLCKYy44nCZzgCJgcvx2UM8czmqak5BCxJMrq37lA==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-1.2.2.tgz",
+      "integrity": "sha512-hR3At21uSrsjjDTWrbu0IMLTpnkpv8IIMFDFaoz43Tmu4LkmAXfH44vNNzpTnf+OAQQCHrb91y/wc2J4x5XgSQ==",
       "requires": {
         "minipass": "^2.2.1"
       }
@@ -582,21 +579,21 @@
       }
     },
     "mocha-jenkins-reporter": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/mocha-jenkins-reporter/-/mocha-jenkins-reporter-0.4.0.tgz",
-      "integrity": "sha512-XkuM8hZUObnj129taCLeEtBw65BnaKzpTGMkeTjuFAIyEVTDpM6LQByLREe1VpgouwHc8FLzSzHtpc4Gbf2ZBQ==",
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/mocha-jenkins-reporter/-/mocha-jenkins-reporter-0.4.2.tgz",
+      "integrity": "sha512-ofQ41SUX5Uh3eHLn/ki4UTsh/7Yuk6p8N3RbxB275TLPErjkJGXuiT5i0haJ51UdJ+bkUhdyIpcCOHS3XSNVsg==",
       "dev": true,
       "requires": {
-        "diff": "1.0.7",
+        "diff": "4.0.1",
         "mkdirp": "0.5.1",
         "mocha": "^5.2.0",
         "xml": "^1.0.1"
       },
       "dependencies": {
         "diff": {
-          "version": "1.0.7",
-          "resolved": "https://registry.npmjs.org/diff/-/diff-1.0.7.tgz",
-          "integrity": "sha1-JLuwAcSn1VIhaefKvbLCgU7ZHPQ=",
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.1.tgz",
+          "integrity": "sha512-s2+XdvhPCOF01LRQBC8hf4vhbVmI2CGS5aZnxLJlT5FtdhPCDFq80q++zK2KlrVorVDdL5BOGZ/VfLrVtYNF+Q==",
           "dev": true
         }
       }
@@ -604,124 +601,544 @@
     "ms": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+      "dev": true
     },
     "nan": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.10.0.tgz",
-      "integrity": "sha512-bAdJv7fBLhWC+/Bls0Oza+mvTaNQtP+1RyhhhvD95pgUJz6XM5IzgmxOkItJ9tkoCiplvAnXI1tNmmUD/eScyA=="
+      "version": "2.14.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.0.tgz",
+      "integrity": "sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg=="
     },
     "needle": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/needle/-/needle-2.2.1.tgz",
-      "integrity": "sha512-t/ZswCM9JTWjAdXS9VpvqhI2Ct2sL2MdY4fUXqGJaGBk13ge99ObqRksRTbBE56K+wxUXwwfZYOuZHifFW9q+Q==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/needle/-/needle-2.4.0.tgz",
+      "integrity": "sha512-4Hnwzr3mi5L97hMYeNl8wRW/Onhy4nUKR/lVemJ8gJedxxUyBLm9kkrDColJvoSfwi0jCNhD+xCdOtiGDQiRZg==",
       "requires": {
-        "debug": "^2.1.2",
+        "debug": "^3.2.6",
         "iconv-lite": "^0.4.4",
         "sax": "^1.2.4"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "2.6.9",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-          "requires": {
-            "ms": "2.0.0"
-          }
-        }
       }
     },
     "node-appc": {
-      "version": "0.2.48",
-      "resolved": "https://registry.npmjs.org/node-appc/-/node-appc-0.2.48.tgz",
-      "integrity": "sha512-fKPynW61a+PmqssitvJXxN2FZAN/w4eBvmE5zqJXl+eDfOip/b26y7SIGGJOn23KjAYX2uyl2Oy/+qTaRz/gHQ==",
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/node-appc/-/node-appc-0.3.4.tgz",
+      "integrity": "sha512-DFJCttcjDmbKS/Z2oPHugp+MjfZ/dsT25dLf2gXzujPOH+zAWOH03079dokon0/hp0zbZu3ksFmrx+JIWtV97Q==",
       "requires": {
         "adm-zip": "^0.4.11",
         "async": "~2.6.1",
         "colors": "~1.3.0",
         "diff": "~3.5.0",
-        "fs-extra": "~6.0.1",
+        "fs-extra": "~7.0.0",
         "optimist": "^0.6.1",
-        "request": "~2.87.0",
-        "semver": "~5.5.0",
+        "request": "~2.88.0",
+        "semver": "~6.0.0",
         "sprintf": "^0.1.5",
-        "temp": "~0.8.3",
+        "temp": "~0.9.0",
         "uglify-js": "~3.4.0",
         "uuid": "~3.3.2",
         "xmldom": "^0.1.27"
       },
       "dependencies": {
         "semver": {
-          "version": "5.5.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz",
-          "integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA=="
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.0.0.tgz",
+          "integrity": "sha512-0UewU+9rFapKFnlbirLi3byoOuhrSsli/z/ihNnvM24vgF+8sNBiI1LZPBSH9wJKUwaUbw+s3hToDLCXkrghrQ=="
         }
       }
     },
     "node-ios-device": {
-      "version": "1.6.2",
-      "resolved": "https://registry.npmjs.org/node-ios-device/-/node-ios-device-1.6.2.tgz",
-      "integrity": "sha512-3FElomo+1XB10Sse9atKj1GXq2PUR7+1VJQegP4R1Ghq4sQf17eT2yG4cnAdJbvkJHtcJxqW/ZQMz9L5E6hNWg==",
+      "version": "1.6.3",
+      "resolved": "https://registry.npmjs.org/node-ios-device/-/node-ios-device-1.6.3.tgz",
+      "integrity": "sha512-ERmLRacvOWSJJxLiuJSOqR+RzjzSL7xMKClvuU5Gb5T//pXXpH4HVAQymthfD0Fjq4caqEMzSw2HkdBbvP3oWw==",
       "requires": {
-        "debug": "^3.1.0",
-        "nan": "^2.10.0",
-        "node-pre-gyp": "^0.10.0",
+        "debug": "^4.1.0",
+        "nan": "^2.11.1",
+        "node-pre-gyp": "^0.12.0",
         "node-pre-gyp-init": "^1.1.0"
       },
       "dependencies": {
-        "debug": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+        "abbrev": {
+          "version": "1.1.1",
+          "bundled": true
+        },
+        "ansi-regex": {
+          "version": "2.1.1",
+          "bundled": true
+        },
+        "aproba": {
+          "version": "1.2.0",
+          "bundled": true
+        },
+        "are-we-there-yet": {
+          "version": "1.1.5",
+          "bundled": true,
           "requires": {
-            "ms": "2.0.0"
+            "delegates": "^1.0.0",
+            "readable-stream": "^2.0.6"
+          }
+        },
+        "balanced-match": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "brace-expansion": {
+          "version": "1.1.11",
+          "bundled": true,
+          "requires": {
+            "balanced-match": "^1.0.0",
+            "concat-map": "0.0.1"
+          }
+        },
+        "chownr": {
+          "version": "1.1.1",
+          "bundled": true
+        },
+        "code-point-at": {
+          "version": "1.1.0",
+          "bundled": true
+        },
+        "concat-map": {
+          "version": "0.0.1",
+          "bundled": true
+        },
+        "console-control-strings": {
+          "version": "1.1.0",
+          "bundled": true
+        },
+        "core-util-is": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "debug": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "deep-extend": {
+          "version": "0.6.0",
+          "bundled": true
+        },
+        "delegates": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "detect-libc": {
+          "version": "1.0.3",
+          "bundled": true
+        },
+        "fs-minipass": {
+          "version": "1.2.5",
+          "bundled": true,
+          "requires": {
+            "minipass": "^2.2.1"
+          }
+        },
+        "fs.realpath": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "gauge": {
+          "version": "2.7.4",
+          "bundled": true,
+          "requires": {
+            "aproba": "^1.0.3",
+            "console-control-strings": "^1.0.0",
+            "has-unicode": "^2.0.0",
+            "object-assign": "^4.1.0",
+            "signal-exit": "^3.0.0",
+            "string-width": "^1.0.1",
+            "strip-ansi": "^3.0.1",
+            "wide-align": "^1.1.0"
+          }
+        },
+        "glob": {
+          "version": "7.1.3",
+          "bundled": true,
+          "requires": {
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
+        },
+        "has-unicode": {
+          "version": "2.0.1",
+          "bundled": true
+        },
+        "iconv-lite": {
+          "version": "0.4.24",
+          "bundled": true,
+          "requires": {
+            "safer-buffer": ">= 2.1.2 < 3"
+          }
+        },
+        "ignore-walk": {
+          "version": "3.0.1",
+          "bundled": true,
+          "requires": {
+            "minimatch": "^3.0.4"
+          }
+        },
+        "inflight": {
+          "version": "1.0.6",
+          "bundled": true,
+          "requires": {
+            "once": "^1.3.0",
+            "wrappy": "1"
+          }
+        },
+        "inherits": {
+          "version": "2.0.3",
+          "bundled": true
+        },
+        "ini": {
+          "version": "1.3.5",
+          "bundled": true
+        },
+        "is-fullwidth-code-point": {
+          "version": "1.0.0",
+          "bundled": true,
+          "requires": {
+            "number-is-nan": "^1.0.0"
+          }
+        },
+        "isarray": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "minimatch": {
+          "version": "3.0.4",
+          "bundled": true,
+          "requires": {
+            "brace-expansion": "^1.1.7"
+          }
+        },
+        "minimist": {
+          "version": "0.0.8",
+          "bundled": true
+        },
+        "minipass": {
+          "version": "2.3.5",
+          "bundled": true,
+          "requires": {
+            "safe-buffer": "^5.1.2",
+            "yallist": "^3.0.0"
+          }
+        },
+        "minizlib": {
+          "version": "1.1.1",
+          "bundled": true,
+          "requires": {
+            "minipass": "^2.2.1"
+          }
+        },
+        "mkdirp": {
+          "version": "0.5.1",
+          "bundled": true,
+          "requires": {
+            "minimist": "0.0.8"
           }
         },
         "ms": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+        },
+        "needle": {
+          "version": "2.2.4",
+          "bundled": true,
+          "requires": {
+            "debug": "^2.1.2",
+            "iconv-lite": "^0.4.4",
+            "sax": "^1.2.4"
+          },
+          "dependencies": {
+            "debug": {
+              "version": "2.6.9",
+              "bundled": true,
+              "requires": {
+                "ms": "2.0.0"
+              }
+            },
+            "ms": {
+              "version": "2.0.0",
+              "bundled": true
+            }
+          }
         },
         "node-pre-gyp": {
-          "version": "0.10.0",
-          "resolved": "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.10.0.tgz",
-          "integrity": "sha512-G7kEonQLRbcA/mOoFoxvlMrw6Q6dPf92+t/l0DFSMuSlDoWaI9JWIyPwK0jyE1bph//CUEL65/Fz1m2vJbmjQQ==",
+          "version": "0.12.0",
+          "bundled": true,
           "requires": {
             "detect-libc": "^1.0.2",
             "mkdirp": "^0.5.1",
-            "needle": "^2.2.0",
+            "needle": "^2.2.1",
             "nopt": "^4.0.1",
             "npm-packlist": "^1.1.6",
             "npmlog": "^4.0.2",
-            "rc": "^1.1.7",
+            "rc": "^1.2.7",
             "rimraf": "^2.6.1",
             "semver": "^5.3.0",
             "tar": "^4"
           }
+        },
+        "nopt": {
+          "version": "4.0.1",
+          "bundled": true,
+          "requires": {
+            "abbrev": "1",
+            "osenv": "^0.1.4"
+          }
+        },
+        "npm-bundled": {
+          "version": "1.0.5",
+          "bundled": true
+        },
+        "npm-packlist": {
+          "version": "1.1.12",
+          "bundled": true,
+          "requires": {
+            "ignore-walk": "^3.0.1",
+            "npm-bundled": "^1.0.1"
+          }
+        },
+        "npmlog": {
+          "version": "4.1.2",
+          "bundled": true,
+          "requires": {
+            "are-we-there-yet": "~1.1.2",
+            "console-control-strings": "~1.1.0",
+            "gauge": "~2.7.3",
+            "set-blocking": "~2.0.0"
+          }
+        },
+        "number-is-nan": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "object-assign": {
+          "version": "4.1.1",
+          "bundled": true
+        },
+        "once": {
+          "version": "1.4.0",
+          "bundled": true,
+          "requires": {
+            "wrappy": "1"
+          }
+        },
+        "os-homedir": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "os-tmpdir": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "osenv": {
+          "version": "0.1.5",
+          "bundled": true,
+          "requires": {
+            "os-homedir": "^1.0.0",
+            "os-tmpdir": "^1.0.0"
+          }
+        },
+        "path-is-absolute": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "process-nextick-args": {
+          "version": "2.0.0",
+          "bundled": true
+        },
+        "rc": {
+          "version": "1.2.8",
+          "bundled": true,
+          "requires": {
+            "deep-extend": "^0.6.0",
+            "ini": "~1.3.0",
+            "minimist": "^1.2.0",
+            "strip-json-comments": "~2.0.1"
+          },
+          "dependencies": {
+            "minimist": {
+              "version": "1.2.0",
+              "bundled": true
+            }
+          }
+        },
+        "readable-stream": {
+          "version": "2.3.6",
+          "bundled": true,
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.1.1",
+            "util-deprecate": "~1.0.1"
+          }
+        },
+        "rimraf": {
+          "version": "2.6.2",
+          "bundled": true,
+          "requires": {
+            "glob": "^7.0.5"
+          }
+        },
+        "safe-buffer": {
+          "version": "5.1.2",
+          "bundled": true
+        },
+        "safer-buffer": {
+          "version": "2.1.2",
+          "bundled": true
+        },
+        "sax": {
+          "version": "1.2.4",
+          "bundled": true
+        },
+        "semver": {
+          "version": "5.6.0",
+          "bundled": true
+        },
+        "set-blocking": {
+          "version": "2.0.0",
+          "bundled": true
+        },
+        "signal-exit": {
+          "version": "3.0.2",
+          "bundled": true
+        },
+        "string-width": {
+          "version": "1.0.2",
+          "bundled": true,
+          "requires": {
+            "code-point-at": "^1.0.0",
+            "is-fullwidth-code-point": "^1.0.0",
+            "strip-ansi": "^3.0.0"
+          }
+        },
+        "string_decoder": {
+          "version": "1.1.1",
+          "bundled": true,
+          "requires": {
+            "safe-buffer": "~5.1.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "3.0.1",
+          "bundled": true,
+          "requires": {
+            "ansi-regex": "^2.0.0"
+          }
+        },
+        "strip-json-comments": {
+          "version": "2.0.1",
+          "bundled": true
+        },
+        "tar": {
+          "version": "4.4.8",
+          "bundled": true,
+          "requires": {
+            "chownr": "^1.1.1",
+            "fs-minipass": "^1.2.5",
+            "minipass": "^2.3.4",
+            "minizlib": "^1.1.1",
+            "mkdirp": "^0.5.0",
+            "safe-buffer": "^5.1.2",
+            "yallist": "^3.0.2"
+          }
+        },
+        "util-deprecate": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "wide-align": {
+          "version": "1.1.3",
+          "bundled": true,
+          "requires": {
+            "string-width": "^1.0.2 || 2"
+          },
+          "dependencies": {
+            "ansi-regex": {
+              "version": "3.0.0",
+              "bundled": true
+            },
+            "is-fullwidth-code-point": {
+              "version": "2.0.0",
+              "bundled": true
+            },
+            "string-width": {
+              "version": "2.1.1",
+              "bundled": true,
+              "requires": {
+                "is-fullwidth-code-point": "^2.0.0",
+                "strip-ansi": "^4.0.0"
+              }
+            },
+            "strip-ansi": {
+              "version": "4.0.0",
+              "bundled": true,
+              "requires": {
+                "ansi-regex": "^3.0.0"
+              }
+            }
+          }
+        },
+        "wrappy": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "yallist": {
+          "version": "3.0.3",
+          "bundled": true
         }
       }
     },
     "node-pre-gyp": {
-      "version": "0.10.0",
-      "resolved": "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.10.0.tgz",
-      "integrity": "sha512-G7kEonQLRbcA/mOoFoxvlMrw6Q6dPf92+t/l0DFSMuSlDoWaI9JWIyPwK0jyE1bph//CUEL65/Fz1m2vJbmjQQ==",
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.10.3.tgz",
+      "integrity": "sha512-d1xFs+C/IPS8Id0qPTZ4bUT8wWryfR/OzzAFxweG+uLN85oPzyo2Iw6bVlLQ/JOdgNonXLCoRyqDzDWq4iw72A==",
       "requires": {
         "detect-libc": "^1.0.2",
         "mkdirp": "^0.5.1",
-        "needle": "^2.2.0",
+        "needle": "^2.2.1",
         "nopt": "^4.0.1",
         "npm-packlist": "^1.1.6",
         "npmlog": "^4.0.2",
-        "rc": "^1.1.7",
+        "rc": "^1.2.7",
         "rimraf": "^2.6.1",
         "semver": "^5.3.0",
         "tar": "^4"
       },
       "dependencies": {
-        "semver": {
-          "version": "5.5.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz",
-          "integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA=="
+        "glob": {
+          "version": "7.1.4",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.4.tgz",
+          "integrity": "sha512-hkLPepehmnKk41pUGm3sYxoFs/umurYfYJCerbXEyFIWcAzvpipAgVkBqqT9RBKMGjnq6kMuyYwha6csxbiM1A==",
+          "requires": {
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
+        },
+        "rimraf": {
+          "version": "2.7.1",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+          "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+          "requires": {
+            "glob": "^7.1.3"
+          }
         }
       }
     },
@@ -743,14 +1160,14 @@
       }
     },
     "npm-bundled": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/npm-bundled/-/npm-bundled-1.0.3.tgz",
-      "integrity": "sha512-ByQ3oJ/5ETLyglU2+8dBObvhfWXX8dtPZDMePCahptliFX2iIuhyEszyFk401PZUNQH20vvdW5MLjJxkwU80Ow=="
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/npm-bundled/-/npm-bundled-1.0.6.tgz",
+      "integrity": "sha512-8/JCaftHwbd//k6y2rEWp6k1wxVfpFzB6t1p825+cUb7Ym2XQfhwIC5KwhrvzZRJu+LtDE585zVaS32+CGtf0g=="
     },
     "npm-packlist": {
-      "version": "1.1.10",
-      "resolved": "https://registry.npmjs.org/npm-packlist/-/npm-packlist-1.1.10.tgz",
-      "integrity": "sha512-AQC0Dyhzn4EiYEfIUjCdMl0JJ61I2ER9ukf/sLxJUcZHfo+VyEfz2rMJgLZSS1v30OxPQe1cN0LZA1xbcaVfWA==",
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/npm-packlist/-/npm-packlist-1.4.4.tgz",
+      "integrity": "sha512-zTLo8UcVYtDU3gdeaFu2Xu0n0EvelfHDGuqtNIn5RO7yQj4H1TqNdBc/yZjxnWA0PVB8D3Woyp0i5B43JwQ6Vw==",
       "requires": {
         "ignore-walk": "^3.0.1",
         "npm-bundled": "^1.0.1"
@@ -773,9 +1190,9 @@
       "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
     },
     "oauth-sign": {
-      "version": "0.8.2",
-      "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
-      "integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM="
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
+      "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ=="
     },
     "object-assign": {
       "version": "4.1.1",
@@ -829,14 +1246,19 @@
       "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
     },
     "process-nextick-args": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
-      "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw=="
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
+    },
+    "psl": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/psl/-/psl-1.4.0.tgz",
+      "integrity": "sha512-HZzqCGPecFLyoRj5HLfuDSKYTJkAfB5thKBIkRHtGjWwY7p1dAyveIbXIq4tO0KYfDF2tHqPUgY9SDnGm00uFw=="
     },
     "punycode": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
-      "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4="
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
+      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
     },
     "qs": {
       "version": "6.5.2",
@@ -873,47 +1295,54 @@
         "safe-buffer": "~5.1.1",
         "string_decoder": "~1.1.1",
         "util-deprecate": "~1.0.1"
+      },
+      "dependencies": {
+        "safe-buffer": {
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+        }
       }
     },
     "request": {
-      "version": "2.87.0",
-      "resolved": "https://registry.npmjs.org/request/-/request-2.87.0.tgz",
-      "integrity": "sha512-fcogkm7Az5bsS6Sl0sibkbhcKsnyon/jV1kF3ajGmF0c8HrttdKTPRT9hieOaQHA5HEq6r8OyWOo/o781C1tNw==",
+      "version": "2.88.0",
+      "resolved": "https://registry.npmjs.org/request/-/request-2.88.0.tgz",
+      "integrity": "sha512-NAqBSrijGLZdM0WZNsInLJpkJokL72XYjUpnB0iwsRgxh7dB6COrHnTBNwN0E+lHDAJzu7kLAkDeY08z2/A0hg==",
       "requires": {
         "aws-sign2": "~0.7.0",
-        "aws4": "^1.6.0",
+        "aws4": "^1.8.0",
         "caseless": "~0.12.0",
-        "combined-stream": "~1.0.5",
-        "extend": "~3.0.1",
+        "combined-stream": "~1.0.6",
+        "extend": "~3.0.2",
         "forever-agent": "~0.6.1",
-        "form-data": "~2.3.1",
-        "har-validator": "~5.0.3",
+        "form-data": "~2.3.2",
+        "har-validator": "~5.1.0",
         "http-signature": "~1.2.0",
         "is-typedarray": "~1.0.0",
         "isstream": "~0.1.2",
         "json-stringify-safe": "~5.0.1",
-        "mime-types": "~2.1.17",
-        "oauth-sign": "~0.8.2",
+        "mime-types": "~2.1.19",
+        "oauth-sign": "~0.9.0",
         "performance-now": "^2.1.0",
-        "qs": "~6.5.1",
-        "safe-buffer": "^5.1.1",
-        "tough-cookie": "~2.3.3",
+        "qs": "~6.5.2",
+        "safe-buffer": "^5.1.2",
+        "tough-cookie": "~2.4.3",
         "tunnel-agent": "^0.6.0",
-        "uuid": "^3.1.0"
+        "uuid": "^3.3.2"
       }
     },
     "rimraf": {
-      "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
-      "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
+      "version": "2.6.3",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
+      "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
       "requires": {
-        "glob": "^7.0.5"
+        "glob": "^7.1.3"
       },
       "dependencies": {
         "glob": {
-          "version": "7.1.2",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
-          "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+          "version": "7.1.4",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.4.tgz",
+          "integrity": "sha512-hkLPepehmnKk41pUGm3sYxoFs/umurYfYJCerbXEyFIWcAzvpipAgVkBqqT9RBKMGjnq6kMuyYwha6csxbiM1A==",
           "requires": {
             "fs.realpath": "^1.0.0",
             "inflight": "^1.0.4",
@@ -926,9 +1355,9 @@
       }
     },
     "safe-buffer": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.0.tgz",
+      "integrity": "sha512-fZEwUGbVl7kouZs1jCdMLdt95hdIv0ZeHg6L7qPeciMZhZ+/gdesW4wgTARkrFWEpspjEATAzUGPG8N2jJiwbg=="
     },
     "safer-buffer": {
       "version": "2.1.2",
@@ -941,9 +1370,9 @@
       "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw=="
     },
     "semver": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
-      "integrity": "sha1-myzl094C0XxgEq0yaqa00M9U+U8="
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.1.tgz",
+      "integrity": "sha512-PqpAxfrEhlSUWge8dwIp4tZnQ25DIOthpiaHNIthsjEFQD6EvqUKUDM7L8O2rShkFccYo1VjJR0coWfNkCubRw=="
     },
     "set-blocking": {
       "version": "2.0.0",
@@ -1020,9 +1449,9 @@
       "integrity": "sha1-j4PjmpMXwaUCy324BQ5Rxnn27c8="
     },
     "sshpk": {
-      "version": "1.14.2",
-      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.14.2.tgz",
-      "integrity": "sha1-xvxhZIo9nE52T9P8306hBeSSupg=",
+      "version": "1.16.1",
+      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.16.1.tgz",
+      "integrity": "sha512-HXXqVUq7+pcKeLqqZj6mHFUMvXtOJt1uoUx09pFW6011inTMxqI8BA8PM95myrIyyKwdnzjdFjLiE6KBPVtJIg==",
       "requires": {
         "asn1": "~0.2.3",
         "assert-plus": "^1.0.0",
@@ -1051,6 +1480,13 @@
       "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
       "requires": {
         "safe-buffer": "~5.1.0"
+      },
+      "dependencies": {
+        "safe-buffer": {
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+        }
       }
     },
     "strip-ansi": {
@@ -1076,41 +1512,41 @@
       }
     },
     "tar": {
-      "version": "4.4.4",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-4.4.4.tgz",
-      "integrity": "sha512-mq9ixIYfNF9SK0IS/h2HKMu8Q2iaCuhDDsZhdEag/FHv8fOaYld4vN7ouMgcSSt5WKZzPs8atclTcJm36OTh4w==",
+      "version": "4.4.11",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-4.4.11.tgz",
+      "integrity": "sha512-iI4zh3ktLJKaDNZKZc+fUONiQrSn9HkCFzamtb7k8FFmVilHVob7QsLX/VySAW8lAviMzMbFw4QtFb4errwgYA==",
       "requires": {
-        "chownr": "^1.0.1",
+        "chownr": "^1.1.1",
         "fs-minipass": "^1.2.5",
-        "minipass": "^2.3.3",
-        "minizlib": "^1.1.0",
+        "minipass": "^2.6.4",
+        "minizlib": "^1.2.1",
         "mkdirp": "^0.5.0",
         "safe-buffer": "^5.1.2",
-        "yallist": "^3.0.2"
+        "yallist": "^3.0.3"
       }
     },
     "temp": {
-      "version": "0.8.3",
-      "resolved": "https://registry.npmjs.org/temp/-/temp-0.8.3.tgz",
-      "integrity": "sha1-4Ma8TSa5AxJEEOT+2BEDAU38H1k=",
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/temp/-/temp-0.9.0.tgz",
+      "integrity": "sha512-YfUhPQCJoNQE5N+FJQcdPz63O3x3sdT4Xju69Gj4iZe0lBKOtnAMi0SLj9xKhGkcGhsxThvTJ/usxtFPo438zQ==",
       "requires": {
-        "os-tmpdir": "^1.0.0",
-        "rimraf": "~2.2.6"
-      },
-      "dependencies": {
-        "rimraf": {
-          "version": "2.2.8",
-          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz",
-          "integrity": "sha1-5Dm+Kq7jJzIZUnMPmaiSnk/FBYI="
-        }
+        "rimraf": "~2.6.2"
       }
     },
     "tough-cookie": {
-      "version": "2.3.4",
-      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.4.tgz",
-      "integrity": "sha512-TZ6TTfI5NtZnuyy/Kecv+CnoROnyXn2DN97LontgQpCwsX2XyLYCC0ENhYkehSOwAp8rTQKc/NUIF7BkQ5rKLA==",
+      "version": "2.4.3",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.4.3.tgz",
+      "integrity": "sha512-Q5srk/4vDM54WJsJio3XNn6K2sCG+CQ8G5Wz6bZhRZoAe/+TxjWB/GlFAnYEbkYVlON9FMk/fE3h2RLpPXo4lQ==",
       "requires": {
+        "psl": "^1.1.24",
         "punycode": "^1.4.1"
+      },
+      "dependencies": {
+        "punycode": {
+          "version": "1.4.1",
+          "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+          "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4="
+        }
       }
     },
     "tunnel-agent": {
@@ -1124,22 +1560,21 @@
     "tweetnacl": {
       "version": "0.14.5",
       "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
-      "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
-      "optional": true
+      "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q="
     },
     "uglify-js": {
-      "version": "3.4.7",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.4.7.tgz",
-      "integrity": "sha512-J0M2i1mQA+ze3EdN9SBi751DNdAXmeFLfJrd/MDIkRc3G3Gbb9OPVSx7GIQvVwfWxQARcYV2DTxIkMyDAk3o9Q==",
+      "version": "3.4.10",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.4.10.tgz",
+      "integrity": "sha512-Y2VsbPVs0FIshJztycsO2SfPk7/KAF/T72qzv9u5EpQ4kB2hQoHlhNQTsNyy6ul7lQtqJN/AoWeS23OzEiEFxw==",
       "requires": {
-        "commander": "~2.16.0",
+        "commander": "~2.19.0",
         "source-map": "~0.6.1"
       },
       "dependencies": {
         "commander": {
-          "version": "2.16.0",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-2.16.0.tgz",
-          "integrity": "sha512-sVXqklSaotK9at437sFlFpyOcJonxe0yST/AG9DkQKUdIE6IqGIMv4SfAQSKaJbSdVEJYItASCrBiVQHq1HQew=="
+          "version": "2.19.0",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.19.0.tgz",
+          "integrity": "sha512-6tvAOO+D6OENvRAh524Dh9jcfKTYDQAqvqezbCW82xj5X0pSrcpxtvRKHLG0yBY6SD7PSDrJaj+0AiOcKVd1Xg=="
         }
       }
     },
@@ -1148,15 +1583,23 @@
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
       "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg=="
     },
+    "uri-js": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.2.2.tgz",
+      "integrity": "sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==",
+      "requires": {
+        "punycode": "^2.1.0"
+      }
+    },
     "util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
     },
     "uuid": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
-      "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA=="
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.3.tgz",
+      "integrity": "sha512-pW0No1RGHgzlpHJO1nsVrHKpOEIxkGg1xB+v0ZmdNH5OAeAwzAVrCnI2/6Mtx+Uys6iaylxa+D3g4j63IKKjSQ=="
     },
     "verror": {
       "version": "1.10.0",
@@ -1174,35 +1617,6 @@
       "integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
       "requires": {
         "string-width": "^1.0.2 || 2"
-      },
-      "dependencies": {
-        "ansi-regex": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
-        },
-        "is-fullwidth-code-point": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
-        },
-        "string-width": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-          "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
-          "requires": {
-            "is-fullwidth-code-point": "^2.0.0",
-            "strip-ansi": "^4.0.0"
-          }
-        },
-        "strip-ansi": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-          "requires": {
-            "ansi-regex": "^3.0.0"
-          }
-        }
       }
     },
     "wordwrap": {
@@ -1227,9 +1641,9 @@
       "integrity": "sha1-1QH5ezvbQDr4757MIFcxh6rawOk="
     },
     "yallist": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.2.tgz",
-      "integrity": "sha1-hFK0u36Dx8GI2AQcGoN8dz1ti7k="
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.3.tgz",
+      "integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A=="
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ioslib",
-  "version": "1.7.13",
+  "version": "1.7.14",
   "description": "iOS Utility Library",
   "keywords": [
     "appcelerator",
@@ -34,16 +34,16 @@
   },
   "dependencies": {
     "always-tail": "0.2.0",
-    "async": "^2.6.1",
+    "async": "^2.6.3",
     "bplist-parser": "0.1.1",
-    "debug": "^3.1.0",
+    "debug": "^3.2.6",
     "mkdirp": "0.5.1",
-    "node-appc": "^0.2.48",
-    "node-ios-device": "^1.6.2"
+    "node-appc": "^0.3.4",
+    "node-ios-device": "^1.6.3"
   },
   "devDependencies": {
     "mocha": "^5.2.0",
-    "mocha-jenkins-reporter": "^0.4.0",
+    "mocha-jenkins-reporter": "^0.4.2",
     "should": "^13.2.3"
   },
   "scripts": {

--- a/test/test-ioslib.js
+++ b/test/test-ioslib.js
@@ -19,8 +19,8 @@ describe('ioslib', function () {
 	});
 
 	it('detect all iOS information', function (done) {
-		this.timeout(10000);
-		this.slow(5000);
+		this.timeout(30000);
+		this.slow(25000);
 
 		ioslib.detect(function (err, results) {
 			if (err) {


### PR DESCRIPTION
- fix: Moved simctl and simulator executable definition from findSimulators() to detect() so that exact Xcode simctl path is coupled with each sim handle.
- refactor: Revamped sim runtime lookup and added a device type lookup which eliminated a 3rd level nested for loop and simplifies valid runtime resolution.
- fix: Fixed bug where non-iPhone, non-iPad, and non-Watch device types would be treated as watch devices and ultimately cause an error because Apple TV devices don't have a model number.
- refactor: Removed 'isAvailable' property added in PR #93 since the correct solution is not to track availability, but separate the selected Xcode from the Xcode associated with the requested simulator.
- fix: Added check to ensure watchCompanion cache only considers valid watchOS ranges.
- fix: Correct sort Xcodes in findSimulators() so that the iOS version takes precedence followed by the system selected Xcode and the latest version.
- fix: Select Xcode version based on specified iOS SDK version, system selected version, or latest version and don't worry about the version used to launch the simulator.
- style: Removed a handful of unused variables.
- fix: Fixed simulator device pair compatiblity lookup where >=4.x and >=3.2 would incorrectly include watchOS 5 and 6.
- chore: Updated npm deps within minor/patch ranges.

Related ticket: https://jira.appcelerator.org/browse/TIMOB-27338 and https://jira.appcelerator.org/browse/TIMOB-27397