### PR TITLE
fix: add executable information to simulator when looping over xcodes

### DIFF
--- a/lib/simulator.js
+++ b/lib/simulator.js
@@ -234,8 +234,6 @@ function detect(options, callback) {
 							runtimeLookup[runtime.identifier] = {
 								name:      runtime.name,
 								version:   runtime.version,
-								simctl:    xc.executables.simctl,
-								simulator: xc.executables[/watch/i.test(xc.simRuntimes[runtime.version].name) ? 'watchsimulator' : 'simulator'],
 								xcodeIds:  []
 							};
 						}
@@ -243,6 +241,12 @@ function detect(options, callback) {
 							var xc = xcodeInfo.xcode[xcodeId];
 							if (xc.simRuntimes[runtime.version] && runtimeLookup[runtime.identifier].xcodeIds.indexOf(xcodeId) === -1) {
 								runtimeLookup[runtime.identifier].xcodeIds.push(xcodeId);
+								if (!runtimeLookup[runtime.identifier].simctl) {
+									runtimeLookup[runtime.identifier].simctl = xc.executables.simctl;
+								}
+								if (!runtimeLookup[runtime.identifier].simulator) {
+									runtimeLookup[runtime.identifier].simulator= xc.executables[/watch/i.test(xc.simRuntimes[runtime.version].name) ? 'watchsimulator' : 'simulator'];
+								}
 							}
 						});
 					}


### PR DESCRIPTION
When adding the global simulator runtimes into the runtime info, set the executable information only when we have it and we know the xcode version and simulator are compatible

Fixes [TIMOB-27490](https://jira.appcelerator.org/browse/TIMOB-27490)