### PR TITLE
fix(xcode): detect all sim runtimes and only remove them after detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 2.5.3
+# 2.5.3 (Nov 19, 2019)
 
  * fix(xcode): Fixed bug where compatible iOS runtime filtering was also being applied to watchOS
    runtimes causing them to not be listed.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 2.5.3
+
+ * fix(xcode): Fixed bug where compatible iOS runtime filtering was also being applied to watchOS
+   runtimes causing them to not be listed.
+   [(DAEMON-306)](https://jira.appcelerator.org/browse/DAEMON-306)
+
 # 2.5.2 (Nov 7, 2019)
 
  * fix(simulator): Fixed watchOS sim semver ranges for device pair compatibility lookup and added a

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ioslib",
-  "version": "2.5.2",
+  "version": "2.5.3",
   "publishConfig": {
     "tag": "next"
   },


### PR DESCRIPTION
The code was applying the iOS runtime filtering to watchOS runtimes causing the watchOS runtimes to not be detected.

https://jira.appcelerator.org/browse/DAEMON-306