### PR TITLE
fix: Correctly detect compatible sims so that a sim can be auto-selected

### DIFF
--- a/lib/simulator.js
+++ b/lib/simulator.js
@@ -709,16 +709,9 @@ function findSimulators(options, callback) {
 
 					logger(__('Scanning Xcode %s sims: %s', xcodeIds[i], simVers.join(', ')));
 
-					// it's possible that `options.simVersion` is an iOS SDK version and not
-					// necessarily a iOS Simulator version, so chop off the patch version and we'll
-					// also test that below
-					var shortVer = options.simVersion && appc.version.format(options.simVersion, 2, 2);
-
 					// loop through each xcode simulators
 					for (var j = 0; !simHandle && j < simVers.length; j++) {
-						if ((!options.simVersion || simVers[j] === options.simVersion || (shortVer && appc.version.eq(simVers[j], shortVer))) &&
-							(!options.minIosVersion || appc.version.gte(simVers[j], options.minIosVersion))
-						) {
+						if (!options.minIosVersion || appc.version.gte(simVers[j], options.minIosVersion)) {
 							var sims = simInfo.simulators.ios[simVers[j]];
 
 							sims.sort(compareSims).reverse();

--- a/lib/simulator.js
+++ b/lib/simulator.js
@@ -709,9 +709,14 @@ function findSimulators(options, callback) {
 
 					logger(__('Scanning Xcode %s sims: %s', xcodeIds[i], simVers.join(', ')));
 
+					// it's possible that `options.simVersion` is an iOS SDK version and not
+					// necessarily a iOS Simulator version, so chop off the patch version and we'll
+					// also test that below
+					var shortVer = options.simVersion && appc.version.format(options.simVersion, 2, 2);
+
 					// loop through each xcode simulators
 					for (var j = 0; !simHandle && j < simVers.length; j++) {
-						if ((!options.simVersion || simVers[j] === options.simVersion) &&
+						if ((!options.simVersion || simVers[j] === options.simVersion || (shortVer && appc.version.eq(simVers[j], shortVer))) &&
 							(!options.minIosVersion || appc.version.gte(simVers[j], options.minIosVersion))
 						) {
 							var sims = simInfo.simulators.ios[simVers[j]];

--- a/lib/simulator.js
+++ b/lib/simulator.js
@@ -228,6 +228,7 @@ function detect(options, callback) {
 						};
 					}
 				});
+
 				info.runtimes.forEach(function (runtime) {
 					if (typeRE.test(runtime.identifier)) {
 						var rt = runtimeLookup[runtime.identifier];
@@ -244,8 +245,10 @@ function detect(options, callback) {
 
 						xcodeIds.forEach(function (xcodeId) {
 							var xc = xcodeInfo.xcode[xcodeId];
-							if (xc.simRuntimes[runtime.version] && rt.xcodeIds.indexOf(xcodeId) === -1) {
-								rt.xcodeIds.push(xcodeId);
+							if (xc.simRuntimes[runtime.version]) {
+								if (rt.xcodeIds.indexOf(xcodeId) === -1) {
+									rt.xcodeIds.push(xcodeId);
+								}
 								if (!rt.simctl) {
 									rt.simctl = xc.executables.simctl;
 								}
@@ -286,7 +289,7 @@ function detect(options, callback) {
 							// unsupported, could be an Apple TV device
 							return;
 						}
-						var type = family === 'iphone' || family === 'ipad' ? 'ios' : 'watchos';
+						var simType = family === 'iphone' || family === 'ipad' ? 'ios' : 'watchos';
 
 						// This code finds the sim runtime and builds the list of associated
 						// iOS SDKs which may be different based which Xcode's simctl is run.
@@ -305,8 +308,8 @@ function detect(options, callback) {
 						runtime.versions.forEach(function (runtimeVersion) {
 							var sim;
 
-							results.simulators[type][runtimeVersion] || (results.simulators[type][runtimeVersion] = []);
-							results.simulators[type][runtimeVersion].some(function (s) {
+							results.simulators[simType][runtimeVersion] || (results.simulators[simType][runtimeVersion] = []);
+							results.simulators[simType][runtimeVersion].some(function (s) {
 								if (s.udid === plist.UDID) {
 									sim = s;
 									return true;
@@ -314,11 +317,11 @@ function detect(options, callback) {
 							});
 
 							if (!sim) {
-								results.simulators[type][runtimeVersion].push(sim = {
+								results.simulators[simType][runtimeVersion].push(sim = {
 									udid:           plist.UDID,
 									name:           plist.name,
 									version:        runtimeVersion,
-									type:           type,
+									type:           simType,
 									simctl:         runtime.simctl,
 									simulator:      runtime.simulator,
 
@@ -341,7 +344,7 @@ function detect(options, callback) {
 
 							runtime.xcodeIds.forEach(function (xcodeId) {
 								sim.supportsXcode[xcodeId] = true;
-								if (type === 'ios') {
+								if (simType === 'ios') {
 									sim.supportsWatch[xcodeId] = deviceType.supportsWatch;
 								}
 							});
@@ -690,7 +693,19 @@ function findSimulators(options, callback) {
 				// loop through xcodes
 				for (var i = 0; !simHandle && i < xcodeIds.length; i++) {
 					var xc = xcodeInfo.xcode[xcodeIds[i]];
-					var simVers = xc.sims.sort().reverse();
+
+					var simVersMap = {};
+					Object.keys(simInfo.simulators.ios)
+						.forEach(function (ver) {
+							Object.keys(xc.simDevicePairs)
+								.some(function (iosRange) {
+									if (appc.version.satisfies(ver, iosRange)) {
+										simVersMap[ver] = xc.simDevicePairs[iosRange];
+										return true;
+									}
+								});
+						});
+					var simVers = appc.version.sort(Object.keys(simVersMap)).reverse();
 
 					logger(__('Scanning Xcode %s sims: %s', xcodeIds[i], simVers.join(', ')));
 
@@ -699,7 +714,7 @@ function findSimulators(options, callback) {
 						if ((!options.simVersion || simVers[j] === options.simVersion) &&
 							(!options.minIosVersion || appc.version.gte(simVers[j], options.minIosVersion))
 						) {
-							var sims = simInfo.simulators.ios[simVers[j]] || simInfo.simulators.ios[appc.version.format(simVers[j], 2, 2)];
+							var sims = simInfo.simulators.ios[simVers[j]];
 
 							sims.sort(compareSims).reverse();
 
@@ -721,14 +736,17 @@ function findSimulators(options, callback) {
 										});
 									} else if (sims[k].supportsWatch[xcodeIds[i]]) {
 										// make sure this version of Xcode has a watch simulator that supports the watch app version
-										xc.watchos.sims.some(function (ver) {
-											if (appc.version.gte(ver, options.watchMinOSVersion) && simInfo.simulators.watchos[ver]) {
-												simHandle = new SimHandle(sims[k]);
-												selectedXcode = xcodeInfo.xcode[xcodeIds[i]];
-												const watchSim = simInfo.simulators.watchos[ver].sort(compareSims).reverse()[0];
-												watchSimHandle = new SimHandle(watchSim);
-												return true;
-											}
+										Object.keys(simInfo.simulators.watchos).some(function (watchosVer) {
+											return Object.keys(simVersMap[simVers[j]])
+												.some(function (watchosRange) { // 4.x, 5.x, etc
+													if (appc.version.satisfies(watchosVer, watchosRange) && appc.version.gte(watchosVer, options.watchMinOSVersion)) {
+														simHandle = new SimHandle(sims[k]);
+														selectedXcode = xcodeInfo.xcode[xcodeIds[i]];
+														const watchSim = simInfo.simulators.watchos[watchosVer].sort(compareSims).reverse()[0];
+														watchSimHandle = new SimHandle(watchSim);
+														return true;
+													}
+												});
 										});
 									}
 								} else {

--- a/lib/xcode.js
+++ b/lib/xcode.js
@@ -39,109 +39,109 @@ var cache,
  * what Watch Simulator. It's a mystery!
  */
 const simulatorDevicePairCompatibility = {
-	'>=6.2 <7.0': {        // Xcode 6.2, 6.3, 6.4
-		'>=8.2 <9.0': {    // iOS 8.2, 8.3, 8.4
-			'1.x': true    // watchOS 1.0
+	'>=6.2 <7.0': {             // Xcode 6.2, 6.3, 6.4
+		'>=8.2 <9.0': {         // iOS 8.2, 8.3, 8.4
+			'1.x': true         // watchOS 1.0
 		}
 	},
-	'7.x': {               // Xcode 7.x
-		'>=8.2 <9.0': {    // iOS 8.2, 8.3, 8.4
-			'1.x': true    // watchOS 1.0
+	'7.x': {                    // Xcode 7.x
+		'>=8.2 <9.0': {         // iOS 8.2, 8.3, 8.4
+			'1.x': true         // watchOS 1.0
 		},
-		'>=9.0 <=9.2': {   // iOS 9.0, 9.1, 9.2
+		'>=9.0 <=9.2': {        // iOS 9.0, 9.1, 9.2
 			'>=2.0 <=2.1': true // watchOS 2.0, 2.1
 		},
-		'>=9.3 <10': {     // iOS 9.3
-			'2.2': true    // watchOS 2.2
+		'>=9.3 <10': {          // iOS 9.3
+			'2.2': true         // watchOS 2.2
 		}
 	},
-	'8.x': {               // Xcode 8.x
-		'>=9.0 <=9.2': {   // iOS 9.0, 9.1, 9.2
+	'8.x': {                    // Xcode 8.x
+		'>=9.0 <=9.2': {        // iOS 9.0, 9.1, 9.2
 			'>=2.0 <=2.1': true // watchOS 2.0, 2.1
 		},
-		'>=9.3 <10': {     // iOS 9.x
-			'2.2': true,   // watchOS 2.2
-			'3.x': true    // watchOS 3.x
+		'>=9.3 <10': {          // iOS 9.x
+			'2.2': true,        // watchOS 2.2
+			'3.x': true         // watchOS 3.x
 		},
-		'10.x': {          // iOS 10.x
-			'2.2': true,   // watchOS 2.2
-			'3.x': true    // watchOS 3.x
+		'10.x': {               // iOS 10.x
+			'2.2': true,        // watchOS 2.2
+			'3.x': true         // watchOS 3.x
 		}
 	},
-	'9.x': {               // Xcode 9.x
-		'>=9.0 <=9.2': {   // iOS 9.0, 9.1, 9.2
+	'9.x': {                    // Xcode 9.x
+		'>=9.0 <=9.2': {        // iOS 9.0, 9.1, 9.2
 			'>=2.0 <=2.1': true // watchOS 2.0, 2.1
 		},
-		'>=9.3 <10': {     // iOS 9.x
-			'2.2': true,   // watchOS 2.2
-			'3.x': true    // watchOS 3.x
+		'>=9.3 <10': {          // iOS 9.x
+			'2.2': true,        // watchOS 2.2
+			'3.x': true         // watchOS 3.x
 		},
-		'10.x': {          // iOS 10.x
-			'2.2': true,   // watchOS 2.2
-			'3.x': true    // watchOS 3.x
+		'10.x': {               // iOS 10.x
+			'2.2': true,        // watchOS 2.2
+			'3.x': true         // watchOS 3.x
 		},
-		'11.x': {		   // iOS 11.x
+		'11.x': {		        // iOS 11.x
 			'>=3.2 <4.0': true, // watchOS 3.2
-			'4.x': true    // watchOS 4.x
+			'4.x': true         // watchOS 4.x
 		}
 	},
-	'10.x <10.3': {        // Xcode 10.0-10.2.1
-		'8.x': {},         // iOS 8.x
-		'>=9.0 <=9.2': {   // iOS 9.0, 9.1, 9.2
+	'10.x <10.3': {             // Xcode 10.0-10.2.1
+		'8.x': {},              // iOS 8.x
+		'>=9.0 <=9.2': {        // iOS 9.0, 9.1, 9.2
 			'>=2.0 <=2.1': true // watchOS 2.0, 2.1
 		},
-		'>=9.3 <10': {         // iOS 9.x
-			'2.2': true,   // watchOS 2.2
-			'3.x': true    // watchOS 3.x
+		'>=9.3 <10': {          // iOS 9.x
+			'2.2': true,        // watchOS 2.2
+			'3.x': true         // watchOS 3.x
 		},
 		'>=10.0 <=10.2': {      // iOS 10.0, 10.1, 10.2
 			'2.2': true,        // watchOS 2.2
 			'3.x': true         // watchOS 3.x
 		},
-		'>=10.3 <11': {             // iOS 10.3
+		'>=10.3 <11': {         // iOS 10.3
 			'3.x': true         // watchOS 3.x
 		},
-		'11.x': {		   // iOS 11.x
+		'11.x': {               // iOS 11.x
 			'>=3.2 <4.0': true, // watchOS 3.2
-			'4.x': true    // watchOS 4.x
+			'4.x': true         // watchOS 4.x
 		},
-		'12.x': {		   // iOS 12.x
+		'12.x': {		        // iOS 12.x
 			'>=3.2 <4.0': true, // watchOS 3.2
-			'4.x': true,   // watchOS 4.x
-			'5.x': true    // watchOS 5.x
+			'4.x': true,        // watchOS 4.x
+			'5.x': true         // watchOS 5.x
 		}
 	},
 	'>=10.3 <11': {
-		'>=10.3 <11': {             // iOS 10.3
+		'>=10.3 <11': {         // iOS 10.3
 			'3.x': true         // watchOS 3.x
 		},
-		'11.x': {		   // iOS 11.x
+		'11.x': {		        // iOS 11.x
 			'>=3.2 <4.0': true, // watchOS 3.2
-			'4.x': true    // watchOS 4.x
+			'4.x': true         // watchOS 4.x
 		},
-		'12.x': {		   // iOS 12.x
-			'4.x': true,   // watchOS 4.x
-			'5.x': true    // watchOS 5.x
+		'12.x': {		        // iOS 12.x
+			'4.x': true,        // watchOS 4.x
+			'5.x': true         // watchOS 5.x
 		}
 	},
-	'11.x': {              // Xcode 11.x
-		'>=10.3': {        // iOS 10.3
-			'2.2': true,   // watchOS 2.2
-			'3.x': true    // watchOS 3.x
+	'11.x': {                   // Xcode 11.x
+		'>=10.3 <11': {         // iOS 10.3
+			'2.2': true,        // watchOS 2.2
+			'3.x': true         // watchOS 3.x
 		},
-		'11.x': {		   // iOS 11.x
+		'11.x': {		        // iOS 11.x
 			'>=3.2 <4.0': true, // watchOS 3.2
-			'4.x': true    // watchOS 4.x
+			'4.x': true         // watchOS 4.x
 		},
-		'12.x': {		   // iOS 12.x
-			'4.x': true,    // watchOS 4.x
-			'5.x': true,    // watchOS 5.x
-			'6.x': true    // watchOS 6.x
+		'12.x': {		        // iOS 12.x
+			'4.x': true,        // watchOS 4.x
+			'5.x': true,        // watchOS 5.x
+			'6.x': true         // watchOS 6.x
 		},
-		'13.x': {		   // iOS 13.x
-			'4.x': true,    // watchOS 4.x
-			'5.x': true,    // watchOS 5.x
-			'6.x': true    // watchOS 6.x
+		'13.x': {		        // iOS 13.x
+			'4.x': true,        // watchOS 4.x
+			'5.x': true,        // watchOS 5.x
+			'6.x': true         // watchOS 6.x
 		}
 	}
 };
@@ -404,10 +404,17 @@ exports.detect = function detect(options, callback) {
 
 							// use the device pair compatibility to see if the simruntime is supported by
 							// this Xcode as there isn't a way to programmatically do it
-							Object.keys(globalSimRuntimes).forEach(function (ver) {
-								Object.keys(simulatorDevicePairCompatibility[xcodeRange]).forEach(function (iosRange) {
-									if (appc.version.satisfies(globalSimRuntimes[ver].version, iosRange)) {
-										xc.simRuntimes[ver] = globalSimRuntimes[ver];
+							Object.keys(globalSimRuntimes).forEach(function (runtime) {
+								Object.keys(xc.simDevicePairs).forEach(function (iosRange) {
+									if (/iOS/.test(runtime) && appc.version.satisfies(globalSimRuntimes[runtime].version, iosRange)) {
+										xc.simRuntimes[runtime] = globalSimRuntimes[runtime];
+									} else if (/watchOS/.test(runtime)) {
+										// scan all iOS versions
+										Object.keys(xc.simDevicePairs[iosRange]).forEach(function (watchosRange) {
+											if (appc.version.satisfies(globalSimRuntimes[runtime].version, watchosRange)) {
+												xc.simRuntimes[runtime] = globalSimRuntimes[runtime];
+											}
+										});
 									}
 								});
 							});

--- a/lib/xcode.js
+++ b/lib/xcode.js
@@ -23,6 +23,7 @@ const
 	fs = require('fs'),
 	path = require('path'),
 	readPlist = require('./utilities').readPlist,
+	simctl = require('./simctl'),
 	__ = appc.i18n(__dirname).__;
 
 var cache,
@@ -341,22 +342,23 @@ exports.detect = function detect(options, callback) {
 			function loadXcodeInfo(next) {
 				async.eachSeries(xcodes, function (dir, cb) {
 					var p = new appc.plist(path.join(path.dirname(dir), 'version.plist')),
+						version = p.CFBundleShortVersionString,
 						selected = dir == selectedXcodePath,
-						supported = options.supportedVersions ? appc.version.satisfies(p.CFBundleShortVersionString, options.supportedVersions, true) : true,
-						ver = p.CFBundleShortVersionString + ':' + p.ProductBuildVersion,
+						supported = options.supportedVersions ? appc.version.satisfies(version, options.supportedVersions, true) : true,
+						id = version + ':' + p.ProductBuildVersion,
 						f;
 
-					if (results.xcode[ver] && !selected && dir > results.xcode[ver].path) {
+					if (results.xcode[id] && !selected && dir > results.xcode[id].path) {
 						return cb();
 					}
 
 					var watchos = null;
-					if (appc.version.gte(p.CFBundleShortVersionString, '7.0')) {
+					if (appc.version.gte(version, '7.0')) {
 						watchos = {
 							sdks: findSDKs(path.join(dir, 'Platforms', 'WatchOS.platform', 'Developer', 'SDKs'), /^WatchOS(.+)\.sdk$/, options.minWatchosVersion),
-							sims: findSims(path.join(dir, 'Platforms', 'WatchSimulator.platform', 'Developer', 'SDKs'), /^WatchSimulator(.+)\.sdk$/, /^watchOS (.+)\.simruntime$/, options.minWatchosVersion)
+							sims: []
 						};
-					} else if (appc.version.gte(p.CFBundleShortVersionString, '6.2')) {
+					} else if (appc.version.gte(version, '6.2')) {
 						watchos = {
 							sdks: ['1.0'],
 							sims: ['1.0']
@@ -365,19 +367,19 @@ exports.detect = function detect(options, callback) {
 
 					var tvos = {
 						sdks: findSDKs(path.join(dir, 'Platforms', 'AppleTVOS.platform', 'Developer', 'SDKs'), /^AppleTVOS(.+)\.sdk$/, options.minTVosVersion),
-						sims: findSims(path.join(dir, 'Platforms', 'AppleTVSimulator.platform', 'Developer', 'SDKs'), /^AppleTVSimulator(.+)\.sdk$/, /^tvOS (.+)\.simruntime$/, options.minTVosVersion)
+						sims: [] // nobody cares
 					};
 
-					var xc = results.xcode[ver] = {
+					var xc = results.xcode[id] = {
 						xcodeapp:       dir.replace(/\/Contents\/Developer\/?$/, ''),
 						path:           dir,
 						selected:       selected,
-						version:        p.CFBundleShortVersionString,
+						version:        version,
 						build:          p.ProductBuildVersion,
 						supported:      supported,
 						eulaAccepted:   false,
 						sdks:           findSDKs(path.join(dir, 'Platforms', 'iPhoneOS.platform', 'Developer', 'SDKs'), /^iPhoneOS(.+)\.sdk$/, options.minIosVersion),
-						sims:           findSims(path.join(dir, 'Platforms', 'iPhoneSimulator.platform', 'Developer', 'SDKs'), /^iPhoneSimulator(.+)\.sdk$/, /^iPhoneOS(.+)\.sdk$/, options.minIosVersion, p.CFBundleShortVersionString),
+						sims:           [],
 						simDeviceTypes: {},
 						simRuntimes:    {},
 						simDevicePairs: {},
@@ -482,31 +484,52 @@ exports.detect = function detect(options, callback) {
 						}
 					}
 
-					selected && (results.selectedXcode = xc);
+					// determine the compatible sims
+					simctl.list({ simctl: xc.executables.simctl }, function (err, info) {
+						if (err) {
+							return next(err);
+						}
 
-					if (supported === false) {
-						results.issues.push({
-							id: 'IOS_XCODE_TOO_OLD',
-							type: 'warning',
-							message: __('Xcode %s is too old and is no longer supported.', '__' + p.CFBundleShortVersionString + '__') + '\n' +
-								__('The minimum supported Xcode version is Xcode %s.', appc.version.parseMin(options.supportedVersions)),
-							xcodeVer: p.CFBundleShortVersionString,
-							minSupportedVer: appc.version.parseMin(options.supportedVersions)
+						var rtRegExp = /(iOS|watchOS)-(.+)$/;
+						Object.keys(info.devices).forEach(function (rt) {
+							var m = rt.match(rtRegExp);
+							if (m) {
+								var dest = m[1] === 'iOS' ? xc.sims : xc.watchos.sims;
+								var ver = m[2].replace(/-/g, '.');
+								if (dest.indexOf(ver) === -1) {
+									dest.push(ver);
+								}
+							}
 						});
-					} else if (supported === 'maybe') {
-						results.issues.push({
-							id: 'IOS_XCODE_TOO_NEW',
-							type: 'warning',
-							message: __('Xcode %s may or may not work as expected.', '__' + p.CFBundleShortVersionString + '__') + '\n' +
-								__('The maximum supported Xcode version is Xcode %s.', appc.version.parseMax(options.supportedVersions, true)),
-							xcodeVer: p.CFBundleShortVersionString,
-							maxSupportedVer: appc.version.parseMax(options.supportedVersions, true)
-						});
-					}
 
-					appc.subprocess.run(xc.executables.xcodebuild, [ '-checkFirstLaunchStatus' ], function (code, out, err) {
-						xc.eulaAccepted = (code === 0);
-						cb();
+						xc.sims.sort();
+						xc.watchos.sims.sort();
+						selected && (results.selectedXcode = xc);
+
+						if (supported === false) {
+							results.issues.push({
+								id: 'IOS_XCODE_TOO_OLD',
+								type: 'warning',
+								message: __('Xcode %s is too old and is no longer supported.', '__' + version + '__') + '\n' +
+									__('The minimum supported Xcode version is Xcode %s.', appc.version.parseMin(options.supportedVersions)),
+								xcodeVer: version,
+								minSupportedVer: appc.version.parseMin(options.supportedVersions)
+							});
+						} else if (supported === 'maybe') {
+							results.issues.push({
+								id: 'IOS_XCODE_TOO_NEW',
+								type: 'warning',
+								message: __('Xcode %s may or may not work as expected.', '__' + version + '__') + '\n' +
+									__('The maximum supported Xcode version is Xcode %s.', appc.version.parseMax(options.supportedVersions, true)),
+								xcodeVer: version,
+								maxSupportedVer: appc.version.parseMax(options.supportedVersions, true)
+							});
+						}
+
+						appc.subprocess.run(xc.executables.xcodebuild, [ '-checkFirstLaunchStatus' ], function (code, out, err) {
+							xc.eulaAccepted = (code === 0);
+							cb();
+						});
 					});
 				}, next);
 			},


### PR DESCRIPTION
https://jira.appcelerator.org/browse/TIMOB-27647

Fixed a several year old bug where the iPhone Simulator SDK was treated as a iOS Simulator _version_. This means you could have a sim sdk of 13.2.2, but the available ios sim is actually 13.3. In other words, the iPhone Simulator SDK is an apple and the iOS Sim version is an orange and ioslib has been trying to associate the two.

This fix correctly pairs Xcodes with simulators using sim runtimes.

This PR also fixes a handful of other small bugs:
* Fixed iOS semver range causing incorrect iOS and watchOS SDKs from being selectable... I believe this only affects users with more than one Xcode installed.
* Fixed bug where global watchOS sim runtimes were being filtered out because they were being compared as if they were iOS sim versions.
* Fixed ambiguous `type` variable that may or may not have caused issues.
* Fixed bug where sim runtimes within an Xcode were being filtered when one version of Xcode was already associated to a sim, but didn't have a valid simctl and simulator executables (edge case and probably only possible with bad Xcode installation).
* Fixed bug with autoselecting both an iOS sim and a watchOS sim. The old code was relying on the potentially false positive list of watchOS sims instead of the actual list of watchOS sims.
* Little big of indentation cleanup with the `simulatorDevicePairCompatibility`.

To test, I used these snippets along with running the SDK builds:

```js
require('./index').xcode.detect((err, results) => {
	if (err) {
		console.error(err);
		process.exit(1);
	} else {
		console.log(results.xcode);
	}
});
```
```js
require('./index').simulator.detect((err, results) => {
	if (err) {
		console.error(err);
		process.exit(1);
	} else {
		console.log(results);
	}
});
```
```js
require('./index').simulator.findSimulators({
	logger: console.log,
	// watchAppBeingInstalled: true,
	iosVersion: '13.1' // 13.2.2, 13.1, 12.4
}, (err, results) => {
	if (err) {
		console.error(err);
		process.exit(1);
	} else {
		console.log(results);
	}
});
```