### PR TITLE
fix(simulator): do not follow symlinks when walking dataDir to cleanup log files

### DIFF
--- a/lib/simulator.js
+++ b/lib/simulator.js
@@ -927,7 +927,13 @@ function launch(simHandleOrUDID, options, callback) {
 					if (fs.existsSync(dir)) {
 						return fs.readdirSync(dir).some(function (name) {
 							var subdir = path.join(dir, name);
-							if (fs.existsSync(subdir) && fs.statSync(subdir).isDirectory()) {
+
+							if (!fs.existsSync(subdir)) {
+								return;
+							}
+
+							var subdirStats = fs.lstatSync(subdir);
+							if (subdirStats.isDirectory() && !subdirStats.isSymbolicLink()) {
 								return walk(subdir);
 							}
 						});

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "ioslib",
-  "version": "1.7.24",
+  "version": "1.7.25",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ioslib",
-  "version": "1.7.24",
+  "version": "1.7.25",
   "description": "iOS Utility Library",
   "keywords": [
     "appcelerator",


### PR DESCRIPTION
Appears the new iOS 15 sims have a symlink'd directory which ioslib does not like at all. So lets not walk those directories

Fixes TIMOB-28498