### PR TITLE
fix(simulator): add in detection for processing logged json objects

### DIFF
--- a/lib/simulator.js
+++ b/lib/simulator.js
@@ -1748,14 +1748,27 @@ function launch(simHandleOrUDID, options, callback) {
 								let found = false;
 								let detectedCrash = false;
 								(function walk(dir) {
-									var logFile = path.join(dir, 'Documents', options.logFilename);
+									let processingJsonObject = false;
+									const logFile = path.join(dir, 'Documents', options.logFilename);
 									if (fs.existsSync(logFile)) {
 										emitter.emit('log-debug', __('Found application log file: %s', logFile));
 										logFileTail = new Tail(logFile, '\n', { interval: 500, start: 0 });
 										logFileTail.on('line', function (msg) {
 											const m = msg.match(logRegExp);
 
+											if (!m && processingJsonObject) {
+												emitter.emit('log-file', msg);
+											}
+
+											if (!m && processingJsonObject && msg.startsWith('}')) {
+												processingJsonObject = false;
+											}
+
 											if (m) {
+
+												if (m[1].endsWith('{')) {
+													processingJsonObject = true;
+												}
 
 												emitter.emit('log-file', m[1]);
 

--- a/test/test-simulator.js
+++ b/test/test-simulator.js
@@ -12,7 +12,7 @@
 /**
  * To run these tests do the following:
  * 1. Update the xcVersion below
- * 2. Update the iphoneSim, ipadSim, and watchosSim to point to valid UDIDs for your machine
+ * 2. Update the iphoneSim, ipadSim, and watchosSim to point to valid UDIDs for your machine. The UDIDs should come from the last simulator shown for a version in ti info output
  * 3. If you get provisioning profile errors, ensure that the TestApp project is setup correctly
 */
 
@@ -26,10 +26,10 @@ const
 	path = require('path'),
 
 	// these will vary by machine
-	xcVersion = '12.4',
-	iphoneSim = 'ADF9395D-11BE-47F4-9499-8665D1D6FA07', // iPhone 12 Pro Max
-	ipadSim = '6DAFA4CA-859F-42BA-901D-F6E1AE84C080', // iPad Pro (12.9-inch) (4th generation)
-	watchosSim = '22B18EDA-9743-452E-8865-68FD833D56EF'; // Apple Watch Series 6 - 44mm (WatchOS 7.2)
+	xcVersion = '13.0',
+	iphoneSim = '2A1AB1A5-73BE-4536-93F2-BA20D307E1B4', // iPhone 12 Pro Max
+	ipadSim = 'F3D0DAA8-7449-4D85-BAE5-278704A432B4', // iPad Pro (12.9-inch) (4th generation)
+	watchosSim = '0E855BDE-862C-4360-8720-351785A5B201'; // Apple Watch Series 6 - 44mm (WatchOS 7.2)
 
 function checkSims(sims) {
 	should(sims).be.an.Array;
@@ -242,7 +242,7 @@ describe('simulator', function () {
 			should(simHandle.udid).equal(iphoneSim);
 			assert(watchSimHandle === null);
 			should(selectedXcode).be.ok;
-			should(selectedXcode.version).equal('12.4');
+			should(selectedXcode.version).equal(xcVersion);
 			done();
 		});
 	});
@@ -573,7 +573,7 @@ describe('simulator', function () {
 				autoExit: true,
 				hide: true,
 				logFilename: 'TestApp.log'
-			}).on('log', function (line) {
+			}).on('log-file', function (line) {
 				counter++;
 			}).on('log-debug', function (line, simHandle) {
 				logger((simHandle ? '[' + simHandle.family.toUpperCase() + '] ' : '') + '[DEBUG]', line);
@@ -585,9 +585,9 @@ describe('simulator', function () {
 			}).on('app-started', function (simHandle) {
 				started = true;
 			}).on('app-quit', function (err) {
-				should(err).not.be.ok;
-				should(launched).be.ok;
-				should(started).be.ok;
+				should(err).not.be.ok();
+				should(launched).equal(true);
+				should(started).equal(true);
 				should(counter).not.equal(0);
 				done();
 			});


### PR DESCRIPTION
[Ticket](https://jira.appcelerator.org/browse/TIMOB-28542)

This is an attempt at fixing the handling of logged JSON objects which now no longer show fully due to the changes in b06258a7558e544a7c4bc482f93bb6b7c03072e9

We process the log line by line so for each line below will be processed individually and will be ignored as it does not include the app name.

Given that you can do things like `console.log('foo', { an: 'object' }, 'foo')` I'm not sure of a better way than using startsWith/endsWith, and I think it's possible this might fall down when combined with something like a `console.group`

```
2021-09-29 15:11:03.550 ticreateapp[45017:3689822] [INFO] {
  x: [33m133[39m,
  y: [33m477.6666564941406[39m,
  bubbles: [33mtrue[39m,
  type: [32m'click'[39m,
  source: Object { 
    [barColor]: [1mnull[22m,
    [navTintColor]: [1mnull[22m,
    [barImage]: [1mnull[22m,
    [translucent]: [1mnull[22m,
    [titleAttributes]: [1mnull[22m,
    [tabBarHidden]: [33mfalse[39m,
    [navBarHidden]: [33mfalse[39m,
    [hidesBarsOnSwipe]: [33mfalse[39m,
    [hidesBarsOnTap]: [33mfalse[39m,
    [hidesBarsWhenKeyboardAppears]: [33mfalse[39m,
    [hidesBackButton]: [33mfalse[39m,
    [orientationModes]: [1mnull[22m,
    [horizontalWrap]: [33mtrue[39m,
    [visible]: [33mtrue[39m,
    [touchEnabled]: [33mtrue[39m,
    [safeAreaPadding]: { right: [33m0[39m, top: [33m47[39m, left: [33m0[39m, bottom: [33m34[39m }
  },
  cancelBubble: [33mfalse[39m
}
```
